### PR TITLE
Update badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build application](https://github.com/learning-process/parallel_programming_course/workflows/Build%20application/badge.svg?branch=master)
+[![Build application](https://github.com/learning-process/parallel_programming_course/actions/workflows/main.yml/badge.svg)](https://github.com/learning-process/parallel_programming_course/actions/workflows/main.yml)
 
 # Parallel Programming Course
 


### PR DESCRIPTION
GitHub updated the path for workflow badges a long time ago: https://github.com/github/docs/pull/3802/files#diff-95d58394efa588c4f92f85274259efb8ca1e10a02bd346549e65b57604c156c4
Docs: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge
Old link became outdated, and it shows old status all the time