### PR TITLE
Hide 'internal_order_test' explicit launch for all tasks

### DIFF
--- a/modules/core/perf/func_tests/test_task.hpp
+++ b/modules/core/perf/func_tests/test_task.hpp
@@ -16,31 +16,23 @@ template <class T>
 class TestTask : public ppc::core::Task {
  public:
   explicit TestTask(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     input_ = reinterpret_cast<T *>(taskData->inputs[0]);
     output_ = reinterpret_cast<T *>(taskData->outputs[0]);
     output_[0] = 0;
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
-    return taskData->outputs_count[0] == 1;
-  }
+  bool validation_impl() override { return taskData->outputs_count[0] == 1; }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
       output_[0] += input_[i];
     }
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
-    return true;
-  }
+  bool post_processing_impl() override { return true; }
 
  private:
   T *input_{};

--- a/modules/core/task/func_tests/test_task.hpp
+++ b/modules/core/task/func_tests/test_task.hpp
@@ -16,31 +16,23 @@ template <class T>
 class TestTask : public ppc::core::Task {
  public:
   explicit TestTask(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     input_ = reinterpret_cast<T *>(taskData->inputs[0]);
     output_ = reinterpret_cast<T *>(taskData->outputs[0]);
     output_[0] = 0;
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
-    return taskData->outputs_count[0] == 1;
-  }
+  bool validation_impl() override { return taskData->outputs_count[0] == 1; }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
       output_[0] += input_[i];
     }
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
-    return true;
-  }
+  bool post_processing_impl() override { return true; }
 
  private:
   T *input_{};

--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -30,16 +30,16 @@ class Task {
   void set_data(std::shared_ptr<TaskData> taskData_);
 
   // validation of data and validation of task attributes before running
-  virtual bool validation() = 0;
+  virtual bool validation();
 
   // pre-processing of input data
-  virtual bool pre_processing() = 0;
+  virtual bool pre_processing();
 
   // realization of current task
-  virtual bool run() = 0;
+  virtual bool run();
 
   // post-processing of output data
-  virtual bool post_processing() = 0;
+  virtual bool post_processing();
 
   // get input and output data
   [[nodiscard]] std::shared_ptr<TaskData> get_data() const;
@@ -49,6 +49,18 @@ class Task {
  protected:
   void internal_order_test(const std::string &str = __builtin_FUNCTION());
   std::shared_ptr<TaskData> taskData;
+
+  // implementation of "validation" function
+  virtual bool validation_impl() = 0;
+
+  // implementation of "pre_processing" function
+  virtual bool pre_processing_impl() = 0;
+
+  // implementation of "run" function
+  virtual bool run_impl() = 0;
+
+  // implementation of "post_processing" function
+  virtual bool post_processing_impl() = 0;
 
  private:
   std::vector<std::string> functions_order;

--- a/modules/core/task/src/task.cpp
+++ b/modules/core/task/src/task.cpp
@@ -16,6 +16,26 @@ std::shared_ptr<ppc::core::TaskData> ppc::core::Task::get_data() const { return 
 
 ppc::core::Task::Task(std::shared_ptr<TaskData> taskData_) { set_data(std::move(taskData_)); }
 
+bool ppc::core::Task::validation() {
+  internal_order_test();
+  return validation_impl();
+}
+
+bool ppc::core::Task::pre_processing() {
+  internal_order_test();
+  return pre_processing_impl();
+}
+
+bool ppc::core::Task::run() {
+  internal_order_test();
+  return run_impl();
+}
+
+bool ppc::core::Task::post_processing() {
+  internal_order_test();
+  return post_processing_impl();
+}
+
 void ppc::core::Task::internal_order_test(const std::string& str) {
   if (!functions_order.empty() && str == functions_order.back() && str == "run") return;
 

--- a/modules/ref/average_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/average_of_vector_elements/include/ref_task.hpp
@@ -18,8 +18,7 @@ template <class InType, class OutType>
 class AverageOfVectorElements : public ppc::core::Task {
  public:
   explicit AverageOfVectorElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InType*>(taskData->inputs[0]);
@@ -31,21 +30,18 @@ class AverageOfVectorElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 1;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     average = static_cast<OutType>(std::accumulate(input_.begin(), input_.end(), 0.0));
     average /= static_cast<OutType>(taskData->inputs_count[0]);
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<OutType*>(taskData->outputs[0])[0] = average;
     return true;
   }

--- a/modules/ref/max_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/max_of_vector_elements/include/ref_task.hpp
@@ -19,8 +19,7 @@ template <class InOutType, class IndexType>
 class MaxOfVectorElements : public ppc::core::Task {
  public:
   explicit MaxOfVectorElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -33,8 +32,7 @@ class MaxOfVectorElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     bool isCountValuesCorrect;
     bool isCountIndexesCorrect;
     // Check count elements of output
@@ -44,16 +42,14 @@ class MaxOfVectorElements : public ppc::core::Task {
     return isCountValuesCorrect && isCountIndexesCorrect;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto result = std::max_element(input_.begin(), input_.end());
     max = static_cast<InOutType>(*result);
     max_index = static_cast<IndexType>(std::distance(input_.begin(), result));
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = max;
     reinterpret_cast<IndexType*>(taskData->outputs[1])[0] = max_index;
     return true;

--- a/modules/ref/min_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/min_of_vector_elements/include/ref_task.hpp
@@ -19,8 +19,7 @@ template <class InOutType, class IndexType>
 class MinOfVectorElements : public ppc::core::Task {
  public:
   explicit MinOfVectorElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -33,8 +32,7 @@ class MinOfVectorElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     bool isCountValuesCorrect;
     bool isCountIndexesCorrect;
     // Check count elements of output
@@ -44,16 +42,14 @@ class MinOfVectorElements : public ppc::core::Task {
     return isCountValuesCorrect && isCountIndexesCorrect;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto result = std::min_element(input_.begin(), input_.end());
     min = static_cast<InOutType>(*result);
     min_index = static_cast<IndexType>(std::distance(input_.begin(), result));
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = min;
     reinterpret_cast<IndexType*>(taskData->outputs[1])[0] = min_index;
     return true;

--- a/modules/ref/most_different_neighbor_elements/include/ref_task.hpp
+++ b/modules/ref/most_different_neighbor_elements/include/ref_task.hpp
@@ -20,8 +20,7 @@ template <class InOutType, class IndexType>
 class MostDifferentNeighborElements : public ppc::core::Task {
  public:
   explicit MostDifferentNeighborElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -34,14 +33,12 @@ class MostDifferentNeighborElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 2 && taskData->outputs_count[1] == 2;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto rotate_in = input_;
     int rot_left = 1;
     rotate(rotate_in.begin(), rotate_in.begin() + rot_left, rotate_in.end());
@@ -59,8 +56,7 @@ class MostDifferentNeighborElements : public ppc::core::Task {
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = l_elem;
     reinterpret_cast<InOutType*>(taskData->outputs[0])[1] = r_elem;
     reinterpret_cast<IndexType*>(taskData->outputs[1])[0] = l_elem_index;

--- a/modules/ref/nearest_neighbor_elements/include/ref_task.hpp
+++ b/modules/ref/nearest_neighbor_elements/include/ref_task.hpp
@@ -20,8 +20,7 @@ template <class InOutType, class IndexType>
 class NearestNeighborElements : public ppc::core::Task {
  public:
   explicit NearestNeighborElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -34,14 +33,12 @@ class NearestNeighborElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 2 && taskData->outputs_count[1] == 2;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto rotate_in = input_;
     int rot_left = 1;
     rotate(rotate_in.begin(), rotate_in.begin() + rot_left, rotate_in.end());
@@ -59,8 +56,7 @@ class NearestNeighborElements : public ppc::core::Task {
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = l_elem;
     reinterpret_cast<InOutType*>(taskData->outputs[0])[1] = r_elem;
     reinterpret_cast<IndexType*>(taskData->outputs[1])[0] = l_elem_index;

--- a/modules/ref/num_of_alternations_signs/include/ref_task.hpp
+++ b/modules/ref/num_of_alternations_signs/include/ref_task.hpp
@@ -20,8 +20,7 @@ template <class InOutType, class CountType>
 class NumOfAlternationsSigns : public ppc::core::Task {
  public:
   explicit NumOfAlternationsSigns(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -33,14 +32,12 @@ class NumOfAlternationsSigns : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 1;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto rotate_in = input_;
     int rot_left = 1;
     rotate(rotate_in.begin(), rotate_in.begin() + rot_left, rotate_in.end());
@@ -52,8 +49,7 @@ class NumOfAlternationsSigns : public ppc::core::Task {
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<CountType*>(taskData->outputs[0])[0] = num;
     return true;
   }

--- a/modules/ref/num_of_orderly_violations/include/ref_task.hpp
+++ b/modules/ref/num_of_orderly_violations/include/ref_task.hpp
@@ -20,8 +20,7 @@ template <class InOutType, class CountType>
 class NumOfOrderlyViolations : public ppc::core::Task {
  public:
   explicit NumOfOrderlyViolations(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -33,14 +32,12 @@ class NumOfOrderlyViolations : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 1;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     auto rotate_in = input_;
     int rot_left = 1;
     rotate(rotate_in.begin(), rotate_in.begin() + rot_left, rotate_in.end());
@@ -53,8 +50,7 @@ class NumOfOrderlyViolations : public ppc::core::Task {
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<CountType*>(taskData->outputs[0])[0] = num;
     return true;
   }

--- a/modules/ref/sum_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/sum_of_vector_elements/include/ref_task.hpp
@@ -16,8 +16,7 @@ template <class InOutType>
 class SumOfVectorElements : public ppc::core::Task {
  public:
   explicit SumOfVectorElements(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -29,20 +28,17 @@ class SumOfVectorElements : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 1;
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     sum = std::accumulate(input_.begin(), input_.end(), 0);
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = sum;
     return true;
   }

--- a/modules/ref/sum_values_by_rows_matrix/include/ref_task.hpp
+++ b/modules/ref/sum_values_by_rows_matrix/include/ref_task.hpp
@@ -18,8 +18,7 @@ template <class InOutType, class IndexType>
 class SumValuesByRowsMatrix : public ppc::core::Task {
  public:
   explicit SumValuesByRowsMatrix(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<InOutType>(taskData->inputs_count[0]);
     auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
@@ -34,23 +33,20 @@ class SumValuesByRowsMatrix : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return static_cast<bool>(taskData->inputs_count[1] == 2 &&
                              taskData->outputs_count[0] == reinterpret_cast<IndexType*>(taskData->inputs[1])[0]);
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     for (size_t i = 0; i < rows; i++) {
       sum_[i] = std::accumulate(input_.begin() + cols * i, input_.begin() + cols * (i + 1), 0.f);
     }
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     for (IndexType i = 0; i < rows; i++) {
       reinterpret_cast<InOutType*>(taskData->outputs[0])[i] = sum_[i];
     }

--- a/modules/ref/vector_dot_product/include/ref_task.hpp
+++ b/modules/ref/vector_dot_product/include/ref_task.hpp
@@ -18,8 +18,7 @@ template <class InOutType>
 class VectorDotProduct : public ppc::core::Task {
  public:
   explicit VectorDotProduct(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
-  bool pre_processing() override {
-    internal_order_test();
+  bool pre_processing_impl() override {
     // Init vectors
     input_ = std::vector<std::vector<InOutType> >(2);
     for (size_t i = 0; i < input_.size(); i++) {
@@ -35,20 +34,17 @@ class VectorDotProduct : public ppc::core::Task {
     return true;
   }
 
-  bool validation() override {
-    internal_order_test();
+  bool validation_impl() override {
     // Check count elements of output
     return taskData->outputs_count[0] == 1 && taskData->inputs_count[0] == taskData->inputs_count[1];
   }
 
-  bool run() override {
-    internal_order_test();
+  bool run_impl() override {
     dor_product = std::inner_product(input_[0].begin(), input_[0].end(), input_[1].begin(), 0.0);
     return true;
   }
 
-  bool post_processing() override {
-    internal_order_test();
+  bool post_processing_impl() override {
     reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = dor_product;
     return true;
   }

--- a/tasks/mpi/example/include/ops_mpi.hpp
+++ b/tasks/mpi/example/include/ops_mpi.hpp
@@ -21,10 +21,10 @@ class TestMPITaskSequential : public ppc::core::Task {
  public:
   explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;
@@ -36,10 +36,10 @@ class TestMPITaskParallel : public ppc::core::Task {
  public:
   explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_, local_input_;

--- a/tasks/mpi/example/src/ops_mpi.cpp
+++ b/tasks/mpi/example/src/ops_mpi.cpp
@@ -20,8 +20,7 @@ std::vector<int> nesterov_a_test_task_mpi::getRandomVector(int sz) {
   return vec;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskSequential::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskSequential::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
@@ -33,14 +32,12 @@ bool nesterov_a_test_task_mpi::TestMPITaskSequential::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskSequential::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskSequential::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskSequential::run() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskSequential::run_impl() {
   if (ops == "+") {
     res = std::accumulate(input_.begin(), input_.end(), 0);
   } else if (ops == "-") {
@@ -51,14 +48,12 @@ bool nesterov_a_test_task_mpi::TestMPITaskSequential::run() {
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskSequential::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskSequential::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskParallel::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskParallel::pre_processing_impl() {
   unsigned int delta = 0;
   if (world.rank() == 0) {
     delta = taskData->inputs_count[0] / world.size();
@@ -87,8 +82,7 @@ bool nesterov_a_test_task_mpi::TestMPITaskParallel::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskParallel::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskParallel::validation_impl() {
   if (world.rank() == 0) {
     // Check count elements of output
     return taskData->outputs_count[0] == 1;
@@ -96,8 +90,7 @@ bool nesterov_a_test_task_mpi::TestMPITaskParallel::validation() {
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskParallel::run() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskParallel::run_impl() {
   int local_res;
   if (ops == "+") {
     local_res = std::accumulate(local_input_.begin(), local_input_.end(), 0);
@@ -116,8 +109,7 @@ bool nesterov_a_test_task_mpi::TestMPITaskParallel::run() {
   return true;
 }
 
-bool nesterov_a_test_task_mpi::TestMPITaskParallel::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_mpi::TestMPITaskParallel::post_processing_impl() {
   if (world.rank() == 0) {
     reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   }

--- a/tasks/omp/example/include/ops_omp.hpp
+++ b/tasks/omp/example/include/ops_omp.hpp
@@ -14,10 +14,10 @@ class TestOMPTaskSequential : public ppc::core::Task {
  public:
   explicit TestOMPTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;
@@ -29,10 +29,10 @@ class TestOMPTaskParallel : public ppc::core::Task {
  public:
   explicit TestOMPTaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;

--- a/tasks/omp/example/src/ops_omp.cpp
+++ b/tasks/omp/example/src/ops_omp.cpp
@@ -22,8 +22,7 @@ std::vector<int> nesterov_a_test_task_omp::getRandomVector(int sz) {
   return vec;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskSequential::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskSequential::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
@@ -35,14 +34,12 @@ bool nesterov_a_test_task_omp::TestOMPTaskSequential::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskSequential::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskSequential::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskSequential::run() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskSequential::run_impl() {
   if (ops == "+") {
     res = std::accumulate(input_.begin(), input_.end(), 1);
   } else if (ops == "-") {
@@ -54,14 +51,12 @@ bool nesterov_a_test_task_omp::TestOMPTaskSequential::run() {
   return true;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskSequential::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskSequential::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskParallel::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskParallel::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
@@ -73,14 +68,12 @@ bool nesterov_a_test_task_omp::TestOMPTaskParallel::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskParallel::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskParallel::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskParallel::run() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskParallel::run_impl() {
   double start = omp_get_wtime();
   auto temp_res = res;
   if (ops == "+") {
@@ -105,8 +98,7 @@ bool nesterov_a_test_task_omp::TestOMPTaskParallel::run() {
   return true;
 }
 
-bool nesterov_a_test_task_omp::TestOMPTaskParallel::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_omp::TestOMPTaskParallel::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }

--- a/tasks/seq/example/include/ops_seq.hpp
+++ b/tasks/seq/example/include/ops_seq.hpp
@@ -11,10 +11,10 @@ namespace nesterov_a_test_task_seq {
 class TestTaskSequential : public ppc::core::Task {
  public:
   explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   int input_{}, res{};

--- a/tasks/seq/example/src/ops_seq.cpp
+++ b/tasks/seq/example/src/ops_seq.cpp
@@ -5,22 +5,19 @@
 
 using namespace std::chrono_literals;
 
-bool nesterov_a_test_task_seq::TestTaskSequential::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_seq::TestTaskSequential::pre_processing_impl() {
   // Init value for input and output
   input_ = reinterpret_cast<int*>(taskData->inputs[0])[0];
   res = 0;
   return true;
 }
 
-bool nesterov_a_test_task_seq::TestTaskSequential::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_seq::TestTaskSequential::validation_impl() {
   // Check count elements of output
   return taskData->inputs_count[0] == 1 && taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_seq::TestTaskSequential::run() {
-  internal_order_test();
+bool nesterov_a_test_task_seq::TestTaskSequential::run_impl() {
   for (int i = 0; i < input_; i++) {
     res++;
   }
@@ -28,8 +25,7 @@ bool nesterov_a_test_task_seq::TestTaskSequential::run() {
   return true;
 }
 
-bool nesterov_a_test_task_seq::TestTaskSequential::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_seq::TestTaskSequential::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }

--- a/tasks/stl/example/include/ops_stl.hpp
+++ b/tasks/stl/example/include/ops_stl.hpp
@@ -15,10 +15,10 @@ class TestSTLTaskSequential : public ppc::core::Task {
  public:
   explicit TestSTLTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;
@@ -30,10 +30,10 @@ class TestSTLTaskParallel : public ppc::core::Task {
  public:
   explicit TestSTLTaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;

--- a/tasks/stl/example/src/ops_stl.cpp
+++ b/tasks/stl/example/src/ops_stl.cpp
@@ -22,8 +22,7 @@ std::vector<int> nesterov_a_test_task_stl::getRandomVector(int sz) {
   return vec;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskSequential::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskSequential::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto *tmp_ptr = reinterpret_cast<int *>(taskData->inputs[0]);
@@ -35,14 +34,12 @@ bool nesterov_a_test_task_stl::TestSTLTaskSequential::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskSequential::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskSequential::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskSequential::run() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskSequential::run_impl() {
   if (ops == "+") {
     res = std::accumulate(input_.begin(), input_.end(), 0);
   } else if (ops == "-") {
@@ -52,8 +49,7 @@ bool nesterov_a_test_task_stl::TestSTLTaskSequential::run() {
   return true;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskSequential::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskSequential::post_processing_impl() {
   reinterpret_cast<int *>(taskData->outputs[0])[0] = res;
   return true;
 }
@@ -77,8 +73,7 @@ void atomOps(std::vector<int> vec, const std::string &ops, std::promise<int> &&p
   pr.set_value(reduction_elem);
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskParallel::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskParallel::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto *tmp_ptr = reinterpret_cast<int *>(taskData->inputs[0]);
@@ -90,14 +85,12 @@ bool nesterov_a_test_task_stl::TestSTLTaskParallel::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskParallel::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskParallel::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskParallel::run() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskParallel::run_impl() {
   const auto nthreads = std::thread::hardware_concurrency();
   const auto delta = (input_.end() - input_.begin()) / nthreads;
 
@@ -119,8 +112,7 @@ bool nesterov_a_test_task_stl::TestSTLTaskParallel::run() {
   return true;
 }
 
-bool nesterov_a_test_task_stl::TestSTLTaskParallel::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_stl::TestSTLTaskParallel::post_processing_impl() {
   reinterpret_cast<int *>(taskData->outputs[0])[0] = res;
   return true;
 }

--- a/tasks/tbb/example/include/ops_tbb.hpp
+++ b/tasks/tbb/example/include/ops_tbb.hpp
@@ -15,10 +15,10 @@ class TestTBBTaskSequential : public ppc::core::Task {
  public:
   explicit TestTBBTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;
@@ -30,10 +30,10 @@ class TestTBBTaskParallel : public ppc::core::Task {
  public:
   explicit TestTBBTaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
       : Task(std::move(taskData_)), ops(std::move(ops_)) {}
-  bool pre_processing() override;
-  bool validation() override;
-  bool run() override;
-  bool post_processing() override;
+  bool pre_processing_impl() override;
+  bool validation_impl() override;
+  bool run_impl() override;
+  bool post_processing_impl() override;
 
  private:
   std::vector<int> input_;

--- a/tasks/tbb/example/src/ops_tbb.cpp
+++ b/tasks/tbb/example/src/ops_tbb.cpp
@@ -22,8 +22,7 @@ std::vector<int> nesterov_a_test_task_tbb::getRandomVector(int sz) {
   return vec;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskSequential::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskSequential::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
@@ -35,14 +34,12 @@ bool nesterov_a_test_task_tbb::TestTBBTaskSequential::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskSequential::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskSequential::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskSequential::run() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskSequential::run_impl() {
   if (ops == "+") {
     res = std::accumulate(input_.begin(), input_.end(), 1);
   } else if (ops == "-") {
@@ -54,14 +51,12 @@ bool nesterov_a_test_task_tbb::TestTBBTaskSequential::run() {
   return true;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskSequential::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskSequential::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskParallel::pre_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskParallel::pre_processing_impl() {
   // Init vectors
   input_ = std::vector<int>(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
@@ -73,14 +68,12 @@ bool nesterov_a_test_task_tbb::TestTBBTaskParallel::pre_processing() {
   return true;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskParallel::validation() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskParallel::validation_impl() {
   // Check count elements of output
   return taskData->outputs_count[0] == 1;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskParallel::run() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskParallel::run_impl() {
   if (ops == "+") {
     res += oneapi::tbb::parallel_reduce(
         oneapi::tbb::blocked_range<std::vector<int>::iterator>(input_.begin(), input_.end()), 0,
@@ -109,8 +102,7 @@ bool nesterov_a_test_task_tbb::TestTBBTaskParallel::run() {
   return true;
 }
 
-bool nesterov_a_test_task_tbb::TestTBBTaskParallel::post_processing() {
-  internal_order_test();
+bool nesterov_a_test_task_tbb::TestTBBTaskParallel::post_processing_impl() {
   reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
   return true;
 }


### PR DESCRIPTION
Use 'impl' methods strategy to hide mandatory function calls. Task class child are adviced to override '*_impl' methods instead of public ones.