### PR TITLE
Refactor tasks architecture

### DIFF
--- a/modules/core/perf/include/perf.hpp
+++ b/modules/core/perf/include/perf.hpp
@@ -8,45 +8,43 @@
 
 #include "core/task/include/task.hpp"
 
-namespace ppc {
-namespace core {
+namespace ppc::core {
 
 struct PerfAttr {
   // count of task's running
-  uint64_t num_running;
+  size_t num_running;
   std::function<double(void)> current_timer = [&] { return 0.0; };
 };
 
 struct PerfResults {
   // measurement of task's time (in seconds)
   double time_sec = 0.0;
-  enum TypeOfRunning { PIPELINE, TASK_RUN, NONE } type_of_running = NONE;
+  enum class RunType : std::uint8_t { Pipeline, TaskRun, None } run_type = RunType::None;
+
   constexpr const static double MAX_TIME = 10.0;
 };
 
 class Perf {
  public:
   // Init performance analysis with initialized task and initialized data
-  explicit Perf(std::shared_ptr<Task> task_);
+  explicit Perf(BaseTask& task_);
   // Set task with initialized task and initialized data for performance
   // analysis c
-  void set_task(std::shared_ptr<Task> task_);
+  void set_task(BaseTask& task_);
   // Check performance of full task's pipeline:  pre_processing() ->
   // validation() -> run() -> post_processing()
-  void pipeline_run(const std::shared_ptr<PerfAttr>& perfAttr,
-                    const std::shared_ptr<ppc::core::PerfResults>& perfResults);
+  void pipeline_run(PerfAttr& perfAttr, ppc::core::PerfResults& perfResults);
   // Check performance of task's run() function
-  void task_run(const std::shared_ptr<PerfAttr>& perfAttr, const std::shared_ptr<ppc::core::PerfResults>& perfResults);
+  void task_run(PerfAttr& perfAttr, ppc::core::PerfResults& perfResults);
   // Pint results for automation checkers
-  static void print_perf_statistic(const std::shared_ptr<PerfResults>& perfResults);
+  static void print_perf_statistic(const PerfResults& perfResults);
 
  private:
-  std::shared_ptr<Task> task;
-  static void common_run(const std::shared_ptr<PerfAttr>& perfAttr, const std::function<void()>& pipeline,
-                         const std::shared_ptr<ppc::core::PerfResults>& perfResults);
+  BaseTask* task{nullptr};
+  static void common_run(PerfAttr& perfAttr, const std::function<void()>& pipeline,
+                         ppc::core::PerfResults& perfResults);
 };
 
-}  // namespace core
-}  // namespace ppc
+}  // namespace ppc::core
 
 #endif  // MODULES_CORE_INCLUDE_PERF_HPP_

--- a/modules/core/perf/src/perf.cpp
+++ b/modules/core/perf/src/perf.cpp
@@ -2,78 +2,84 @@
 
 #include <gtest/gtest.h>
 
+#include <cassert>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <utility>
 
-ppc::core::Perf::Perf(std::shared_ptr<Task> task_) { set_task(std::move(task_)); }
+ppc::core::Perf::Perf(BaseTask& task_) { set_task(task_); }
 
-void ppc::core::Perf::set_task(std::shared_ptr<Task> task_) {
-  task_->get_data()->state_of_testing = TaskData::StateOfTesting::PERF;
-  task = std::move(task_);
+void ppc::core::Perf::set_task(BaseTask& task_) {
+  task_.testing_mode = BaseTask::TestingMode::Perf;
+  task = &task_;
 }
 
-void ppc::core::Perf::pipeline_run(const std::shared_ptr<PerfAttr>& perfAttr,
-                                   const std::shared_ptr<ppc::core::PerfResults>& perfResults) {
-  perfResults->type_of_running = PerfResults::TypeOfRunning::PIPELINE;
+void ppc::core::Perf::pipeline_run(PerfAttr& perfAttr, ppc::core::PerfResults& perfResults) {
+  perfResults.run_type = PerfResults::RunType::Pipeline;
 
   common_run(
-      std::move(perfAttr),
+      perfAttr,
       [&]() {
-        task->validation();
-        task->pre_processing();
+        task->validate();
+        task->pre_process();
         task->run();
-        task->post_processing();
+        task->post_process();
       },
-      std::move(perfResults));
+      perfResults);
 }
 
-void ppc::core::Perf::task_run(const std::shared_ptr<PerfAttr>& perfAttr,
-                               const std::shared_ptr<ppc::core::PerfResults>& perfResults) {
-  perfResults->type_of_running = PerfResults::TypeOfRunning::TASK_RUN;
+void ppc::core::Perf::task_run(PerfAttr& perfAttr, ppc::core::PerfResults& perfResults) {
+  perfResults.run_type = PerfResults::RunType::TaskRun;
 
-  task->validation();
-  task->pre_processing();
-  common_run(std::move(perfAttr), [&]() { task->run(); }, std::move(perfResults));
-  task->post_processing();
+  task->validate();
+  task->pre_process();
+  common_run(
+      perfAttr, [&]() { task->run(); }, perfResults);
+  task->post_process();
 
-  task->validation();
-  task->pre_processing();
+  task->validate();
+  task->pre_process();
   task->run();
-  task->post_processing();
+  task->post_process();
 }
 
-void ppc::core::Perf::common_run(const std::shared_ptr<PerfAttr>& perfAttr, const std::function<void()>& pipeline,
-                                 const std::shared_ptr<ppc::core::PerfResults>& perfResults) {
-  auto begin = perfAttr->current_timer();
-  for (uint64_t i = 0; i < perfAttr->num_running; i++) {
+void ppc::core::Perf::common_run(PerfAttr& perfAttr, const std::function<void()>& pipeline,
+                                 ppc::core::PerfResults& perfResults) {
+  const auto begin = perfAttr.current_timer();
+  for (size_t i = 0; i < perfAttr.num_running; i++) {
     pipeline();
   }
-  auto end = perfAttr->current_timer();
-  perfResults->time_sec = end - begin;
+  const auto end = perfAttr.current_timer();
+  perfResults.time_sec = end - begin;
 }
 
-void ppc::core::Perf::print_perf_statistic(const std::shared_ptr<PerfResults>& perfResults) {
+void ppc::core::Perf::print_perf_statistic(const PerfResults& perfResults) {
   std::string relative_path(::testing::UnitTest::GetInstance()->current_test_info()->file());
   std::string ppc_regex_template("parallel_programming_course");
   std::string perf_regex_template("perf_tests");
   std::string type_test_name;
 
-  auto time_secs = perfResults->time_sec;
+  auto time_secs = perfResults.time_sec;
 
-  if (perfResults->type_of_running == PerfResults::TypeOfRunning::TASK_RUN) {
-    type_test_name = "task_run";
-  } else if (perfResults->type_of_running == PerfResults::TypeOfRunning::PIPELINE) {
-    type_test_name = "pipeline";
-  } else if (perfResults->type_of_running == PerfResults::TypeOfRunning::NONE) {
-    type_test_name = "none";
+  switch (perfResults.run_type) {
+    case PerfResults::RunType::TaskRun:
+      type_test_name = "task_run";
+      break;
+    case PerfResults::RunType::Pipeline:
+      type_test_name = "pipeline";
+      break;
+    case PerfResults::RunType::None:
+      type_test_name = "none";
+      break;
+    default:
+      assert(false);
+      break;
   }
 
-  auto first_found_position = relative_path.find(ppc_regex_template) + ppc_regex_template.length() + 1;
+  const auto first_found_position = relative_path.find(ppc_regex_template) + ppc_regex_template.length() + 1;
   relative_path.erase(0, first_found_position);
 
-  auto last_found_position = relative_path.find(perf_regex_template) - 1;
+  const auto last_found_position = relative_path.find(perf_regex_template) - 1;
   relative_path.erase(last_found_position, relative_path.length() - 1);
 
   std::stringstream perf_res_str;
@@ -82,11 +88,11 @@ void ppc::core::Perf::print_perf_statistic(const std::shared_ptr<PerfResults>& p
     std::cout << relative_path << ":" << type_test_name << ":" << perf_res_str.str() << std::endl;
   } else {
     std::stringstream errMsg;
-    errMsg << std::endl << "Task execute time need to be: ";
-    errMsg << "time < " << PerfResults::MAX_TIME << " secs." << std::endl;
-    errMsg << "Original time in secs: " << time_secs << std::endl;
+    errMsg << "\nTask execute time need to be: ";
+    errMsg << "time < " << PerfResults::MAX_TIME << " secs.\n";
+    errMsg << "Original time in secs: " << time_secs << '\n';
     perf_res_str << std::fixed << std::setprecision(10) << -1.0;
     std::cout << relative_path << ":" << type_test_name << ":" << perf_res_str.str() << std::endl;
-    throw std::runtime_error(errMsg.str().c_str());
+    throw std::runtime_error(errMsg.str());
   }
 }

--- a/modules/core/task/func_tests/task_tests.cpp
+++ b/modules/core/task/func_tests/task_tests.cpp
@@ -6,151 +6,123 @@
 #include "core/task/include/task.hpp"
 
 TEST(task_tests, check_int32_t) {
+  using InOutType = int32_t;
+
   // Create data
-  std::vector<int32_t> in(20, 1);
-  std::vector<int32_t> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<int32_t> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
   test_task.run();
-  test_task.post_processing();
-  ASSERT_EQ(static_cast<size_t>(out[0]), in.size());
+  test_task.post_process();
+  EXPECT_EQ(out, static_cast<InOutType>(in.size()));
 }
 
 TEST(task_tests, check_validate_func) {
+  using InOutType = int32_t;
+
   // Create data
-  std::vector<int32_t> in(20, 1);
-  std::vector<int32_t> out(2, 0);
+  std::vector<InOutType> in(20, 1);
+  std::vector<InOutType> out(2, 0);
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<int32_t> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, false);
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  EXPECT_FALSE(test_task.validate());
 }
 
 TEST(task_tests, check_double) {
+  using InOutType = double;
+
   // Create data
-  std::vector<double> in(20, 1);
-  std::vector<double> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<double> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
   test_task.run();
-  test_task.post_processing();
-  EXPECT_NEAR(out[0], static_cast<double>(in.size()), 1e-6);
+  test_task.post_process();
+  EXPECT_NEAR(out, static_cast<InOutType>(in.size()), 1e-6);
 }
 
 TEST(task_tests, check_uint8_t) {
+  using InOutType = uint32_t;
+
   // Create data
-  std::vector<uint8_t> in(20, 1);
-  std::vector<uint8_t> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<uint8_t> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
   test_task.run();
-  test_task.post_processing();
-  ASSERT_EQ(static_cast<size_t>(out[0]), in.size());
+  test_task.post_process();
+  EXPECT_EQ(out, static_cast<InOutType>(in.size()));
 }
 
 TEST(task_tests, check_int64_t) {
+  using InOutType = int64_t;
+
   // Create data
-  std::vector<int64_t> in(20, 1);
-  std::vector<int64_t> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<int64_t> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
   test_task.run();
-  test_task.post_processing();
-  ASSERT_EQ(static_cast<size_t>(out[0]), in.size());
+  test_task.post_process();
+  EXPECT_EQ(out, static_cast<InOutType>(in.size()));
 }
 
 TEST(task_tests, check_float) {
+  using InOutType = float;
+
   // Create data
-  std::vector<float> in(20, 1);
-  std::vector<float> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<float> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
   test_task.run();
-  test_task.post_processing();
-  EXPECT_NEAR(out[0], in.size(), 1e-3);
+  test_task.post_process();
+  EXPECT_NEAR(out, static_cast<InOutType>(in.size()), 1e-3);
 }
 
 TEST(task_tests, check_wrong_order) {
+  using InOutType = int32_t;
+
   // Create data
-  std::vector<float> in(20, 1);
-  std::vector<float> out(1, 0);
+  std::vector<InOutType> in(20, 1);
+  InOutType out;
 
   // Create TaskData
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data->inputs_count.emplace_back(in.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data->outputs_count.emplace_back(out.size());
-
+  ppc::test::task::TestTask<InOutType>::TaskData task_data(in, out);
   // Create Task
-  ppc::test::task::TestTask<float> test_task(task_data);
-  bool is_valid = test_task.validation();
-  ASSERT_EQ(is_valid, true);
-  test_task.pre_processing();
-  ASSERT_ANY_THROW(test_task.post_processing());
+  ppc::test::task::TestTask<InOutType> test_task(task_data);
+  ASSERT_TRUE(test_task.validate());
+  test_task.pre_process();
+  EXPECT_ANY_THROW(test_task.post_process());
 }
 
 int main(int argc, char **argv) {

--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -10,45 +10,41 @@
 
 namespace ppc::core {
 
-struct TaskData {
-  std::vector<uint8_t *> inputs;
-  std::vector<std::uint32_t> inputs_count;
-  std::vector<uint8_t *> outputs;
-  std::vector<std::uint32_t> outputs_count;
-  enum StateOfTesting { FUNC, PERF } state_of_testing;
-};
+template <typename InType, typename OutType>
+struct GenericTaskData {
+  const std::span<InType> input;
+  std::span<OutType> output;
 
-using TaskDataPtr = std::shared_ptr<ppc::core::TaskData>;
+  GenericTaskData(const std::span<InType>& input_, std::span<OutType> output_)
+      : input(input_), output(std::move(output_)) {}
+  GenericTaskData(const InType& input_, OutType& output_)
+      : input(std::addressof(input_), 1), output(std::addressof(output_), 1) {}
+  GenericTaskData(const std::span<InType>& input_, OutType& output_)
+      : input(input_), output(std::addressof(output_), 1) {}
+  GenericTaskData(const InType& input_, std::span<OutType> output_)
+      : input(std::addressof(input_), 1), output(std::move(output_)) {}
+};
 
 // Memory of inputs and outputs need to be initialized before create object of
 // Task class
-class Task {
+class BaseTask {
  public:
-  explicit Task(TaskDataPtr taskData_);
-
-  // set input and output data
-  void set_data(TaskDataPtr taskData_);
-
   // validation of data and validation of task attributes before running
-  virtual bool validation();
+  virtual bool validate();
 
   // pre-processing of input data
-  virtual bool pre_processing();
+  virtual bool pre_process();
 
-  // realization of current task
+  // implementation of current task
   virtual bool run();
 
   // post-processing of output data
-  virtual bool post_processing();
+  virtual bool post_process();
 
-  // get input and output data
-  [[nodiscard]] TaskDataPtr get_data() const;
-
-  virtual ~Task();
+  enum class TestingMode { Func, Perf } testing_mode = TestingMode::Func;
 
  protected:
-  void internal_order_test(const std::string &str = __builtin_FUNCTION());
-  TaskDataPtr taskData;
+  void internal_order_test(const std::string& str = __builtin_FUNCTION());
 
   // implementation of "validation" function
   virtual bool validation_impl() = 0;
@@ -62,13 +58,47 @@ class Task {
   // implementation of "post_processing" function
   virtual bool post_processing_impl() = 0;
 
- private:
   std::vector<std::string> functions_order;
-  std::vector<std::string> right_functions_order = {"validation", "pre_processing", "run", "post_processing"};
   const double max_test_time = 1.0;
   std::chrono::high_resolution_clock::time_point tmp_time_point;
 };
 
+template <typename InType, typename OutType>
+class Task : public BaseTask {
+ public:
+  using TaskData = GenericTaskData<InType, OutType>;
+
+  explicit Task(TaskData taskData_);
+
+  // set input and output data
+  void set_data(TaskData taskData_);
+
+  // get input and output data
+  const TaskData& get_data() const;
+
+  // create a new input and output data instance
+  static TaskData make_data() { return {}; }
+
+ protected:
+  TaskData taskData;
+};
+
 }  // namespace ppc::core
+
+template <typename InType, typename OutType>
+ppc::core::Task<InType, OutType>::Task(TaskData taskData_)
+    : taskData(std::move(taskData_)) {}
+
+template <typename InType, typename OutType>
+void ppc::core::Task<InType, OutType>::set_data(typename ppc::core::Task<InType, OutType>::TaskData taskData_) {
+  taskData = std::move(taskData_);
+  testing_mode = TestingMode::Func;
+  functions_order.clear();
+}
+
+template <typename InType, typename OutType>
+const typename ppc::core::Task<InType, OutType>::TaskData& ppc::core::Task<InType, OutType>::get_data() const {
+  return taskData;
+}
 
 #endif  // MODULES_CORE_INCLUDE_TASK_HPP_

--- a/modules/ref/average_of_vector_elements/func_tests/ref_tests.cpp
+++ b/modules/ref/average_of_vector_elements/func_tests/ref_tests.cpp
@@ -8,23 +8,17 @@
 TEST(average_of_vector_elements, check_int32_t) {
   // Create data
   std::vector<int32_t> in(1256, 1);
-  std::vector<double> out(1, 0);
+  double out;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<int32_t, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<int32_t, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_NEAR(out[0], 1.0, 1e-5);
+  testTask.post_process();
+  EXPECT_NEAR(out, 1.0, 1e-5);
 }
 
 TEST(average_of_vector_elements, check_validate_func) {
@@ -33,16 +27,10 @@ TEST(average_of_vector_elements, check_validate_func) {
   std::vector<double> out(2, 0);
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<int32_t, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<int32_t, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, false);
+  EXPECT_FALSE(testTask.validate());
 }
 
 TEST(average_of_vector_elements, check_double) {
@@ -51,19 +39,13 @@ TEST(average_of_vector_elements, check_double) {
   std::vector<double> out(1, 0);
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<double, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<double, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
+  testTask.post_process();
   EXPECT_NEAR(out[0], 1.123, 1e-5);
 }
 
@@ -73,19 +55,13 @@ TEST(average_of_vector_elements, check_uint8_t) {
   std::vector<double> out(1, 0);
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<uint8_t, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<uint8_t, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
+  testTask.post_process();
   EXPECT_NEAR(out[0], 2.0, 1e-5);
 }
 
@@ -95,40 +71,28 @@ TEST(average_of_vector_elements, check_int64_t) {
   std::vector<double> out(1, 0);
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<int64_t, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<int64_t, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
+  testTask.post_process();
   EXPECT_NEAR(out[0], 3.0, 1e-5);
 }
 
 TEST(average_of_vector_elements, check_float) {
   // Create data
   std::vector<float> in(1, 1.5f);
-  std::vector<double> out(1, 0);
+  double out;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-
+  ppc::reference::AverageOfVectorElements<float, double>::TaskData taskData(in, out);
   // Create Task
   ppc::reference::AverageOfVectorElements<float, double> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_NEAR(out[0], 1.5, 1e-5);
+  testTask.post_process();
+  EXPECT_NEAR(out, 1.5, 1e-5);
 }

--- a/modules/ref/average_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/average_of_vector_elements/include/ref_task.hpp
@@ -13,16 +13,16 @@ namespace ppc {
 namespace reference {
 
 template <class InType, class OutType>
-class AverageOfVectorElements : public ppc::core::Task {
+class AverageOfVectorElements : public ppc::core::Task<InType, OutType> {
  public:
-  explicit AverageOfVectorElements(ppc::core::TaskDataPtr taskData_) : Task(taskData_) {}
+  explicit AverageOfVectorElements(typename AverageOfVectorElements::TaskData taskData_)
+      : AverageOfVectorElements::Task(taskData_) {}
+
+ protected:
   bool pre_processing_impl() override {
     // Init vectors
-    input_ = std::vector<InType>(taskData->inputs_count[0]);
-    auto tmp_ptr = reinterpret_cast<InType*>(taskData->inputs[0]);
-    for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
-      input_[i] = tmp_ptr[i];
-    }
+    const auto& src = this->taskData.input;
+    input_.assign(src.begin(), src.end());
     // Init value for output
     average = 0.0;
     return true;
@@ -30,17 +30,17 @@ class AverageOfVectorElements : public ppc::core::Task {
 
   bool validation_impl() override {
     // Check count elements of output
-    return taskData->outputs_count[0] == 1;
+    return this->taskData.output.size() == 1;
   }
 
   bool run_impl() override {
     average = static_cast<OutType>(std::accumulate(input_.begin(), input_.end(), 0.0));
-    average /= static_cast<OutType>(taskData->inputs_count[0]);
+    average /= static_cast<OutType>(input_.size());
     return true;
   }
 
   bool post_processing_impl() override {
-    reinterpret_cast<OutType*>(taskData->outputs[0])[0] = average;
+    this->taskData.output[0] = average;
     return true;
   }
 

--- a/modules/ref/max_of_vector_elements/func_tests/ref_tests.cpp
+++ b/modules/ref/max_of_vector_elements/func_tests/ref_tests.cpp
@@ -6,177 +6,103 @@
 #include "ref/max_of_vector_elements/include/ref_task.hpp"
 
 TEST(max_of_vector_elements, check_int32_t) {
+  using InOutType = int32_t;
+  using IndexType = uint64_t;
+
   // Create data
-  std::vector<int32_t> in(1256, 1);
-  std::vector<int32_t> out(1, 0);
-  std::vector<uint64_t> out_index(1, 0);
+  std::vector<InOutType> in(1256, 1);
+  std::pair<IndexType, InOutType> out;
   in[328] = 10;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType>::TaskData taskData(in, out);
   // Create Task
-  ppc::reference::MaxOfVectorElements<int32_t, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType> testTask(taskData);
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  ASSERT_EQ(out[0], 10);
-  ASSERT_EQ(out_index[0], 328ull);
-}
-
-TEST(max_of_vector_elements, check_validate_func_1) {
-  // Create data
-  std::vector<int32_t> in(125, 1);
-  std::vector<int32_t> out(2, 0);
-  std::vector<uint64_t> out_index(1, 0);
-
-  // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
-  // Create Task
-  ppc::reference::MaxOfVectorElements<int32_t, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, false);
-}
-
-TEST(max_of_vector_elements, check_validate_func_2) {
-  // Create data
-  std::vector<int32_t> in(125, 1);
-  std::vector<int32_t> out(1, 0);
-  std::vector<uint64_t> out_index(2, 0);
-
-  // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
-  // Create Task
-  ppc::reference::MaxOfVectorElements<int32_t, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, false);
+  testTask.post_process();
+  EXPECT_EQ(out, std::make_pair(IndexType(328), InOutType(10)));
 }
 
 TEST(max_of_vector_elements, check_double) {
+  using InOutType = double;
+  using IndexType = uint64_t;
+
   // Create data
-  std::vector<double> in(25680, 1);
-  std::vector<double> out(1, 0);
-  std::vector<uint64_t> out_index(1, 0);
+  std::vector<InOutType> in(25680, 1);
+  std::pair<IndexType, InOutType> out;
   in[2] = 1.0001;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType>::TaskData taskData(in, out);
   // Create Task
-  ppc::reference::MaxOfVectorElements<double, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType> testTask(taskData);
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_NEAR(out[0], 1.0001, 1e-6);
-  ASSERT_EQ(out_index[0], 2ull);
+  testTask.post_process();
+  EXPECT_EQ(out.first, 2ull);
+  EXPECT_NEAR(out.second, 1.0001, 1e-6);
 }
 
 TEST(max_of_vector_elements, check_uint8_t) {
+  using InOutType = uint32_t;
+  using IndexType = uint64_t;
+
   // Create data
-  std::vector<uint8_t> in(255, 1);
-  std::vector<uint8_t> out(1, 0);
-  std::vector<uint64_t> out_index(1, 0);
+  std::vector<InOutType> in(1256, 1);
+  std::pair<IndexType, InOutType> out;
+  in[328] = 10;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType>::TaskData taskData(in, out);
   // Create Task
-  ppc::reference::MaxOfVectorElements<uint8_t, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType> testTask(taskData);
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_EQ(out[0], 1);
-  ASSERT_EQ(out_index[0], 0ull);
+  testTask.post_process();
+  EXPECT_EQ(out, std::make_pair(IndexType(0), InOutType(1)));
 }
 
 TEST(max_of_vector_elements, check_int64_t) {
+  using InOutType = int64_t;
+  using IndexType = uint64_t;
+
   // Create data
-  std::vector<int64_t> in(75836, 1);
-  std::vector<int64_t> out(1, 0);
-  std::vector<uint64_t> out_index(1, 0);
+  std::vector<InOutType> in(75836, 1);
+  std::pair<IndexType, InOutType> out;
   in[345] = 256;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType>::TaskData taskData(in, out);
   // Create Task
-  ppc::reference::MaxOfVectorElements<int64_t, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType> testTask(taskData);
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_EQ(out[0], 256ll);
-  ASSERT_EQ(out_index[0], 345ull);
+  testTask.post_process();
+  EXPECT_EQ(out, std::make_pair(IndexType(345), InOutType(256)));
 }
 
 TEST(max_of_vector_elements, check_float) {
+  using InOutType = float;
+  using IndexType = uint64_t;
+
   // Create data
-  std::vector<float> in(1, 1.f);
-  std::vector<float> out(1, 0.f);
-  std::vector<uint64_t> out_index(1, 0);
+  std::vector<InOutType> in(1, 1.f);
+  std::pair<IndexType, InOutType> out;
   in[0] = 1.01f;
 
   // Create TaskData
-  auto taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  taskData->inputs_count.emplace_back(in.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  taskData->outputs_count.emplace_back(out.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t*>(out_index.data()));
-  taskData->outputs_count.emplace_back(out_index.size());
-
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType>::TaskData taskData(in, out);
   // Create Task
-  ppc::reference::MaxOfVectorElements<float, uint64_t> testTask(taskData);
-  bool isValid = testTask.validation();
-  ASSERT_EQ(isValid, true);
-  testTask.pre_processing();
+  ppc::reference::MaxOfVectorElements<InOutType, IndexType> testTask(taskData);
+  ASSERT_TRUE(testTask.validate());
+  testTask.pre_process();
   testTask.run();
-  testTask.post_processing();
-  EXPECT_NEAR(out[0], 1.01f, 1e-6f);
-  ASSERT_EQ(out_index[0], 0ull);
+  testTask.post_process();
+  EXPECT_EQ(out.first, 2ull);
+  EXPECT_NEAR(out.second, 1.01f, 1e-6f);
 }

--- a/modules/ref/max_of_vector_elements/include/ref_task.hpp
+++ b/modules/ref/max_of_vector_elements/include/ref_task.hpp
@@ -14,16 +14,16 @@ namespace ppc {
 namespace reference {
 
 template <class InOutType, class IndexType>
-class MaxOfVectorElements : public ppc::core::Task {
+class MaxOfVectorElements : public ppc::core::Task<InOutType, std::pair<IndexType, InOutType>> {
  public:
-  explicit MaxOfVectorElements(ppc::core::TaskDataPtr taskData_) : Task(taskData_) {}
+  explicit MaxOfVectorElements(typename MaxOfVectorElements::TaskData taskData_)
+      : MaxOfVectorElements::Task(taskData_) {}
+
+ protected:
   bool pre_processing_impl() override {
     // Init vectors
-    input_ = std::vector<InOutType>(taskData->inputs_count[0]);
-    auto tmp_ptr = reinterpret_cast<InOutType*>(taskData->inputs[0]);
-    for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
-      input_[i] = tmp_ptr[i];
-    }
+    const auto& src = this->taskData.input;
+    input_.assign(src.begin(), src.end());
     // Init value for output
     max = 0.0;
     max_index = 0;
@@ -31,13 +31,8 @@ class MaxOfVectorElements : public ppc::core::Task {
   }
 
   bool validation_impl() override {
-    bool isCountValuesCorrect;
-    bool isCountIndexesCorrect;
     // Check count elements of output
-    isCountValuesCorrect = taskData->outputs_count[0] == 1;
-    isCountIndexesCorrect = taskData->outputs_count[1] == 1;
-
-    return isCountValuesCorrect && isCountIndexesCorrect;
+    return this->taskData.output.size() == 1;
   }
 
   bool run_impl() override {
@@ -48,8 +43,7 @@ class MaxOfVectorElements : public ppc::core::Task {
   }
 
   bool post_processing_impl() override {
-    reinterpret_cast<InOutType*>(taskData->outputs[0])[0] = max;
-    reinterpret_cast<IndexType*>(taskData->outputs[1])[0] = max_index;
+    this->taskData.output[0] = std::make_pair(max_index, max);
     return true;
   }
 


### PR DESCRIPTION
**Type safety**. Using `std::span` in TaskData instead of raw pointers with separate supplement of their memory blocks sizes prevents heap overflow errors and simplifies the code overall.

**Less boilerplate**. The current way of initializing TaskData results in a huge amount of boilerplate code that very few people actually understand due to their poor understanding of pointer arithmetic - the need to copy it from test to test increases the likelihood of introducing a hard-to-debug bug unrelated to the task.

**No shared_ptr usage**. If you look closely, it is impossible to imagine a situation where using shared_ptr is justified now - they are used even where they are definitely not needed - for example, in perf tests when creating PerfAnalyzer. If you can give arguments in favor of using shared_ptr, or an example of a situation that cannot be normally implemented without using it, let's discuss it.

