### PR TITLE
Extract main() from example projects

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -70,11 +70,11 @@ foreach(TASK_TYPE ${LIST_OF_TASKS})
     set_target_properties(${exec_func_lib} PROPERTIES LINKER_LANGUAGE CXX)
 
     if (USE_FUNC_TESTS)
-      add_executable(${exec_func_tests} ${FUNC_TESTS_SOURCE_FILES})
+      add_executable(${exec_func_tests} ${FUNC_TESTS_SOURCE_FILES} "${PATH_TO_TASK}/runner.cpp")
       list(APPEND LIST_OF_EXEC_TESTS ${exec_func_tests})
     endif (USE_FUNC_TESTS)
     if (USE_PERF_TESTS)
-      add_executable(${exec_perf_tests} ${PERF_TESTS_SOURCE_FILES})
+      add_executable(${exec_perf_tests} ${PERF_TESTS_SOURCE_FILES} "${PATH_TO_TASK}/runner.cpp")
       list(APPEND LIST_OF_EXEC_TESTS ${exec_perf_tests})
     endif (USE_PERF_TESTS)
 

--- a/tasks/mpi/example/func_tests/main.cpp
+++ b/tasks/mpi/example/func_tests/main.cpp
@@ -225,14 +225,3 @@ TEST(Parallel_Operations_MPI, Test_Max_2) {
     ASSERT_EQ(reference_max[0], global_max[0]);
   }
 }
-
-int main(int argc, char** argv) {
-  boost::mpi::environment env(argc, argv);
-  boost::mpi::communicator world;
-  ::testing::InitGoogleTest(&argc, argv);
-  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
-  if (world.rank() != 0) {
-    delete listeners.Release(listeners.default_result_printer());
-  }
-  return RUN_ALL_TESTS();
-}

--- a/tasks/mpi/example/perf_tests/main.cpp
+++ b/tasks/mpi/example/perf_tests/main.cpp
@@ -85,14 +85,3 @@ TEST(mpi_example_perf_test, test_task_run) {
     ASSERT_EQ(count_size_vector, global_sum[0]);
   }
 }
-
-int main(int argc, char** argv) {
-  boost::mpi::environment env(argc, argv);
-  boost::mpi::communicator world;
-  ::testing::InitGoogleTest(&argc, argv);
-  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
-  if (world.rank() != 0) {
-    delete listeners.Release(listeners.default_result_printer());
-  }
-  return RUN_ALL_TESTS();
-}

--- a/tasks/mpi/runner.cpp
+++ b/tasks/mpi/runner.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+
+int main(int argc, char** argv) {
+  boost::mpi::environment env(argc, argv);
+  boost::mpi::communicator world;
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (world.rank() != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+  }
+  return RUN_ALL_TESTS();
+}

--- a/tasks/omp/example/func_tests/main.cpp
+++ b/tasks/omp/example/func_tests/main.cpp
@@ -194,8 +194,3 @@ TEST(Parallel_Operations_OpenMP, Test_Mult_2) {
   testOmpTaskParallel.post_processing();
   ASSERT_EQ(ref_res[0], par_res[0]);
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/omp/example/perf_tests/main.cpp
+++ b/tasks/omp/example/perf_tests/main.cpp
@@ -69,8 +69,3 @@ TEST(openmp_example_perf_test, test_task_run) {
   ppc::core::Perf::print_perf_statistic(perfResults);
   ASSERT_EQ(count + 1, out[0]);
 }
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/omp/runner.cpp
+++ b/tasks/omp/runner.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tasks/seq/example/func_tests/main.cpp
+++ b/tasks/seq/example/func_tests/main.cpp
@@ -118,8 +118,3 @@ TEST(Sequential, Test_Sum_100) {
   testTaskSequential.post_processing();
   ASSERT_EQ(count, out[0]);
 }
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/seq/example/perf_tests/main.cpp
+++ b/tasks/seq/example/perf_tests/main.cpp
@@ -78,8 +78,3 @@ TEST(sequential_example_perf_test, test_task_run) {
   ppc::core::Perf::print_perf_statistic(perfResults);
   ASSERT_EQ(count, out[0]);
 }
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/seq/runner.cpp
+++ b/tasks/seq/runner.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tasks/stl/example/func_tests/main.cpp
+++ b/tasks/stl/example/func_tests/main.cpp
@@ -199,8 +199,3 @@ TEST(Parallel_Operations_STL_Threads, Test_Diff_2) {
   TestSTLTaskParallel.post_processing();
   ASSERT_EQ(ref_res[0], par_res[0]);
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/stl/example/perf_tests/main.cpp
+++ b/tasks/stl/example/perf_tests/main.cpp
@@ -78,8 +78,3 @@ TEST(stl_example_perf_test, test_task_run) {
   ppc::core::Perf::print_perf_statistic(perfResults);
   ASSERT_EQ(count, out[0]);
 }
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/stl/runner.cpp
+++ b/tasks/stl/runner.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tasks/tbb/example/func_tests/main.cpp
+++ b/tasks/tbb/example/func_tests/main.cpp
@@ -193,8 +193,3 @@ TEST(Parallel_Operations_TBB, Test_Mult_2) {
   testTbbTaskParallel.post_processing();
   ASSERT_EQ(ref_res[0], par_res[0]);
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/tbb/example/perf_tests/main.cpp
+++ b/tasks/tbb/example/perf_tests/main.cpp
@@ -71,8 +71,3 @@ TEST(tbb_example_perf_test, test_task_run) {
   ppc::core::Perf::print_perf_statistic(perfResults);
   ASSERT_EQ(count + 1, out[0]);
 }
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/tasks/tbb/runner.cpp
+++ b/tasks/tbb/runner.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
It will be possible to copy example without thinking about deleting main, and it will be easier to modify runners, for example, inject custom test listeners by modifying a single file.