### PR TITLE
Suppress useless warnings in .yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,3 +3,5 @@ rules:
   line-length:
     max: 120
     level: error
+  truthy: disable
+  document-start: disable


### PR DESCRIPTION
Suppress useless warnings to clean up GitHub "Files changed" page output