### PR TITLE
Use cmake to build scoreboard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,14 +51,17 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install -r requirements.txt
-      - name: Build scoreboard
+      - name: CMake configure
         run: |
-          python3 scoreboard/main.py
+          cmake -S . -B build -DUSE_SCOREBOARD=ON
+      - name: CMake build
+        run: |
+          cmake --build build --parallel
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: scoreboard
-          path: ./scoreboard/
+          path: ./build/scoreboard/html/
   deploy-pages:
     if: github.ref == 'refs/heads/master'
     needs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ message( STATUS "PPC step: Setup external projects" )
 include(cmake/opencv.cmake)
 include(cmake/gtest.cmake)
 
+############################ Scoreboard #############################
+
+message( STATUS "PPC step: Setup scoreboard generator" )
+include(cmake/scoreboard.cmake)
+add_subdirectory(scoreboard)
+
 ############################## Headers ##############################
 
 message( STATUS "PPC step: Setup headers" )

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,4 +1,9 @@
 # Build Core Boost components
+
+if(NOT USE_SEQ AND NOT USE_MPI AND NOT USE_OMP AND NOT USE_TBB AND NOT USE_STL)
+    return()
+endif()
+
 SUBDIRLIST(subdirs ${CMAKE_SOURCE_DIR}/3rdparty/boost/libs)
 foreach(subd ${subdirs})
         include_directories(${CMAKE_SOURCE_DIR}/3rdparty/boost/libs/${subd}/include)

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -1,4 +1,8 @@
 # Build googletest components
+if(NOT USE_SEQ AND NOT USE_MPI AND NOT USE_OMP AND NOT USE_TBB AND NOT USE_STL)
+    return()
+endif()
+
 include_directories(${CMAKE_SOURCE_DIR}/3rdparty/googletest/googletest/include)
 include(ExternalProject)
 ExternalProject_Add(ppc_googletest

--- a/cmake/opencv.cmake
+++ b/cmake/opencv.cmake
@@ -1,5 +1,10 @@
 # Build OpenCV components
 # core highgui imgcodecs imgproc videoio
+
+if(NOT USE_SEQ AND NOT USE_MPI AND NOT USE_OMP AND NOT USE_TBB AND NOT USE_STL)
+    return()
+endif()
+
 include(ExternalProject)
 include_directories(${CMAKE_SOURCE_DIR}/3rdparty/opencv/include)
 if(WIN32)

--- a/cmake/scoreboard.cmake
+++ b/cmake/scoreboard.cmake
@@ -1,0 +1,5 @@
+option(USE_SCOREBOARD OFF)
+if( USE_SCOREBOARD )
+    find_package(Python REQUIRED
+        COMPONENTS Interpreter)
+endif( USE_SCOREBOARD )

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT USE_SEQ AND NOT USE_MPI AND NOT USE_OMP AND NOT USE_TBB AND NOT USE_STL)
+  return()
+endif()
+
 message(STATUS "Modules")
 
 SUBDIRLIST(subdirs ${CMAKE_CURRENT_SOURCE_DIR})

--- a/scoreboard/CMakeLists.txt
+++ b/scoreboard/CMakeLists.txt
@@ -1,0 +1,19 @@
+if (NOT USE_SCOREBOARD)
+    return()
+endif()
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html)
+set(OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/html)
+
+add_custom_target(generate_scoreboard ALL
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/main.py -o ${OUTPUT_DIR}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running main.py"
+)
+
+add_custom_command(TARGET generate_scoreboard POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/static
+        ${OUTPUT_DIR}/static
+    COMMENT "Copying static directory to binary directory"
+)

--- a/scoreboard/main.py
+++ b/scoreboard/main.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from collections import defaultdict
+import argparse
 
 task_types = ['all', 'mpi', 'omp', 'seq', 'stl', 'tbb']
 
@@ -67,7 +68,11 @@ html_content += """
 </html>
 """
 
-output_file = Path('scoreboard/index.html')
+parser = argparse.ArgumentParser(description='Generate HTML scoreboard.')
+parser.add_argument('-o', '--output', type=str, required=True, help='Output file path')
+args = parser.parse_args()
+
+output_file = Path(args.output) / "index.html"
 with open(output_file, 'w') as file:
     file.write(html_content)
 


### PR DESCRIPTION
- Adjust CMake implementation to be able to build without USE_<MPI/OMP/STL/TBB>
- Use CMake to build scoreboard instead of running Python script directly