### PR TITLE
[docs] Enforce the same lest pane template in sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,3 +25,12 @@ gettext_compact = False
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+html_sidebars = {
+    "**": ["globaltoc.html", "sourcelink.html", "searchbox.html"]
+}
+
+html_theme_options = {
+    "collapse_navigation": False,
+    "navigation_depth": 2,
+}


### PR DESCRIPTION
Solve the problem when part of ToC disappears on the left pane on some pages