### PR TITLE
Forbid C-style casts using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: >
   bugprone-*,
   clang-diagnostic-*,
   cppcoreguidelines-init-variables,
+  cppcoreguidelines-pro-type-cstyle-cast,
   llvm-include-order,
   llvm-namespace-comment,
   misc-*,


### PR DESCRIPTION
resolves https://github.com/learning-process/parallel_programming_course/issues/338