### PR TITLE
Enable 'pipefail' in scripts/generate_perf_results.sh

### DIFF
--- a/scripts/generate_perf_results.sh
+++ b/scripts/generate_perf_results.sh
@@ -1,3 +1,5 @@
+set -o pipefail
+
 mkdir -p build/perf_stat_dir
 python3 scripts/run_tests.py --running-type="performance" | tee build/perf_stat_dir/perf_log.txt
 python3 scripts/create_perf_table.py --input build/perf_stat_dir/perf_log.txt --output build/perf_stat_dir


### PR DESCRIPTION
Fail when run_tests.py script execution fails