### PR TITLE
Unify environment variables usage across the project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,39 +114,39 @@ jobs:
       - name: Run func tests (MPI, num_proc=1)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 1
-          OMP_NUM_THREADS: 3
+          PPC_NUM_PROC: 1
+          PPC_NUM_THREADS: 3
       - name: Run func tests (MPI, num_proc=2)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
       - name: Run func tests (MPI, num_proc=3)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 3
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 3
+          PPC_NUM_THREADS: 1
       - name: Run func tests (MPI, num_proc=4)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 4
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 4
+          PPC_NUM_THREADS: 1
       - name: Run func tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run func tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run func tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run func tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
   ubuntu-gcc-test-extended:
     needs:
       - ubuntu-gcc-test
@@ -172,19 +172,19 @@ jobs:
       - name: Run func tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
+          PPC_NUM_THREADS: 5
       - name: Run func tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
+          PPC_NUM_THREADS: 7
       - name: Run func tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
+          PPC_NUM_THREADS: 11
       - name: Run func tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
+          PPC_NUM_THREADS: 13
   ubuntu-clang-build:
     needs:
       - clang-format
@@ -263,39 +263,39 @@ jobs:
       - name: Run func tests (MPI, num_proc=1)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 1
-          OMP_NUM_THREADS: 3
+          PPC_NUM_PROC: 1
+          PPC_NUM_THREADS: 3
       - name: Run func tests (MPI, num_proc=2)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
       - name: Run func tests (MPI, num_proc=3)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 3
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 3
+          PPC_NUM_THREADS: 1
       - name: Run func tests (MPI, num_proc=4)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 4
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 4
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
   ubuntu-clang-test-extended:
     needs:
       - ubuntu-clang-test
@@ -323,19 +323,19 @@ jobs:
       - name: Run tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
+          PPC_NUM_THREADS: 5
       - name: Run tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
+          PPC_NUM_THREADS: 7
       - name: Run tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
+          PPC_NUM_THREADS: 11
       - name: Run tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
+          PPC_NUM_THREADS: 13
   ubuntu-clang-sanitizer-build:
     needs:
       - ubuntu-clang-build
@@ -416,37 +416,37 @@ jobs:
       - name: Run tests (MPI)
         run: python3 scripts/run_tests.py --running-type="processes" --additional-mpi-args="--oversubscribe"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
-          ASAN_RUN: 1
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
+          PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 1
+          PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 2
+          PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 3
+          PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 4
+          PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
   ubuntu-clang-sanitizer-test-extended:
@@ -477,23 +477,23 @@ jobs:
       - name: Run tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 5
+          PPC_ASAN_RUN: 1
       - name: Run tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 7
+          PPC_ASAN_RUN: 1
       - name: Run tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 11
+          PPC_ASAN_RUN: 1
       - name: Run tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
-          ASAN_RUN: 1
+          PPC_NUM_THREADS: 13
+          PPC_ASAN_RUN: 1
   macos-clang-build:
     needs:
       - clang-format
@@ -564,39 +564,39 @@ jobs:
       - name: Run func tests (MPI, num_proc=1)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 1
-          OMP_NUM_THREADS: 3
+          PPC_NUM_PROC: 1
+          PPC_NUM_THREADS: 3
       - name: Run func tests (MPI, num_proc=2)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
       - name: Run func tests (MPI, num_proc=3)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 3
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 3
+          PPC_NUM_THREADS: 1
       - name: Run func tests (MPI, num_proc=4)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 4
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 4
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
   macos-clang-test-extended:
     needs:
       - macos-clang-test
@@ -622,19 +622,19 @@ jobs:
       - name: Run tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
+          PPC_NUM_THREADS: 5
       - name: Run tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
+          PPC_NUM_THREADS: 7
       - name: Run tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
+          PPC_NUM_THREADS: 11
       - name: Run tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
+          PPC_NUM_THREADS: 13
   windows-msvc-build:
     needs:
       - clang-format
@@ -711,39 +711,39 @@ jobs:
       - name: Run func tests (MPI, num_proc=1)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 1
-          OMP_NUM_THREADS: 3
+          PPC_NUM_PROC: 1
+          PPC_NUM_THREADS: 3
       - name: Run func tests (MPI, num_proc=2)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
       - name: Run func tests (MPI, num_proc=3)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 3
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 3
+          PPC_NUM_THREADS: 1
       - name: Run func tests (MPI, num_proc=4)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 4
-          OMP_NUM_THREADS: 1
+          PPC_NUM_PROC: 4
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
   windows-msvc-test-extended:
     needs:
       - windows-msvc-test
@@ -771,19 +771,19 @@ jobs:
       - name: Run tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
+          PPC_NUM_THREADS: 5
       - name: Run tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
+          PPC_NUM_THREADS: 7
       - name: Run tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
+          PPC_NUM_THREADS: 11
       - name: Run tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
+          PPC_NUM_THREADS: 13
   windows-clang-build:
     needs:
       - clang-format
@@ -864,19 +864,19 @@ jobs:
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
   windows-clang-test-extended:
     needs:
       - windows-clang-test
@@ -904,19 +904,19 @@ jobs:
       - name: Run tests (threads, num_threads=5)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 5
+          PPC_NUM_THREADS: 5
       - name: Run tests (threads, num_threads=7)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 7
+          PPC_NUM_THREADS: 7
       - name: Run tests (threads, num_threads=11)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 11
+          PPC_NUM_THREADS: 11
       - name: Run tests (threads, num_threads=13)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 13
+          PPC_NUM_THREADS: 13
   ubuntu-gcc-build-codecov:
     needs:
       - ubuntu-gcc-test-extended
@@ -950,24 +950,24 @@ jobs:
       - name: Run tests (MPI)
         run: python3 scripts/run_tests.py --running-type="processes"
         env:
-          PROC_COUNT: 2
-          OMP_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=1)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 1
+          PPC_NUM_THREADS: 1
       - name: Run tests (threads, num_threads=2)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 2
+          PPC_NUM_THREADS: 2
       - name: Run tests (threads, num_threads=3)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 3
+          PPC_NUM_THREADS: 3
       - name: Run tests (threads, num_threads=4)
         run: python3 scripts/run_tests.py --running-type="threads"
         env:
-          OMP_NUM_THREADS: 4
+          PPC_NUM_THREADS: 4
       - name: Generate gcovr Coverage Data
         run: |
           mkdir cov-report
@@ -1022,14 +1022,14 @@ jobs:
         run: |
           python3 scripts/run_perf_counter.py --required-tests-number=2
         env:
-          OMP_NUM_THREADS: 2
-          PROC_COUNT: 2
+          PPC_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
       - name: Run perf tests
         run: |
           bash -e scripts/generate_perf_results.sh
         env:
-          OMP_NUM_THREADS: 2
-          PROC_COUNT: 2
+          PPC_NUM_THREADS: 2
+          PPC_NUM_PROC: 2
       - name: Archive results
         uses: montudor/action-zip@v1
         with:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Below is the table of contents for the Parallel Programming Course documentation
    user_guide/submit_work
    user_guide/ci
    user_guide/api
+   user_guide/environment_variables
 
 .. toctree::
    :maxdepth: 2

--- a/docs/locale/en/LC_MESSAGES/user_guide/environment_variables.po
+++ b/docs/locale/en/LC_MESSAGES/user_guide/environment_variables.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Learning Process
+# This file is distributed under the same license as the Parallel
+# Programming Course package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Parallel Programming Course \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-26 10:22+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../../../docs/user_guide/environment_variables.rst:2
+msgid "Environment Variables"
+msgstr ""
+
+#: ../../../../docs/user_guide/environment_variables.rst:4
+msgid ""
+"The following environment variables can be used to configure the "
+"project's runtime behavior:"
+msgstr ""
+
+#: ../../../../docs/user_guide/environment_variables.rst:6
+msgid ""
+"``PPC_NUM_PROC``: Specifies the number of processes to launch. "
+"Default: ``1``"
+msgstr ""
+
+#: ../../../../docs/user_guide/environment_variables.rst:9
+msgid ""
+"``PPC_NUM_THREADS``: Specifies the number of threads to use. Default:"
+" ``1``"
+msgstr ""
+
+#: ../../../../docs/user_guide/environment_variables.rst:12
+msgid ""
+"``PPC_ASAN_RUN``: Specifies that application is compiler with "
+"sanitizers. Used by ``scripts/run_tests.py`` to skip ``valgrind`` runs. "
+"Default: ``0``"
+msgstr ""
+

--- a/docs/locale/ru/LC_MESSAGES/user_guide/environment_variables.po
+++ b/docs/locale/ru/LC_MESSAGES/user_guide/environment_variables.po
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Learning Process
+# This file is distributed under the same license as the Parallel
+# Programming Course package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Parallel Programming Course \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-26 10:22+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ru\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../../../docs/user_guide/environment_variables.rst:2
+msgid "Environment Variables"
+msgstr "Переменные окружения"
+
+#: ../../../../docs/user_guide/environment_variables.rst:4
+msgid ""
+"The following environment variables can be used to configure the "
+"project's runtime behavior:"
+msgstr "Следующие переменные окружения могут использоваться для настройки поведения программы во время выполнения:"
+
+#: ../../../../docs/user_guide/environment_variables.rst:6
+msgid ""
+"``PPC_NUM_PROC``: Specifies the number of processes to launch. "
+"Default: ``1``"
+msgstr "``PPC_NUM_PROC``: задаёт количество запускаемых процессов. По умолчанию: ``1``"
+
+#: ../../../../docs/user_guide/environment_variables.rst:9
+msgid ""
+"``PPC_NUM_THREADS``: Specifies the number of threads to use. Default:"
+" ``1``"
+msgstr "``PPC_NUM_THREADS``: задаёт количество используемых потоков. По умолчанию: ``1``"
+
+#: ../../../../docs/user_guide/environment_variables.rst:12
+msgid ""
+"``PPC_ASAN_RUN``: Specifies that application is compiler with "
+"sanitizers. Used by ``scripts/run_tests.py`` to skip ``valgrind`` runs. "
+"Default: ``0``"
+msgstr "``PPC_ASAN_RUN``: указывает, что приложение собрано с санитайзерами. Используется в ``scripts/run_tests.py`` для пропуска запусков под ``valgrind``. По умолчанию: ``0``"
+

--- a/docs/user_guide/environment_variables.rst
+++ b/docs/user_guide/environment_variables.rst
@@ -1,0 +1,13 @@
+Environment Variables
+=====================
+
+The following environment variables can be used to configure the project's runtime behavior:
+
+- ``PPC_NUM_PROC``: Specifies the number of processes to launch.
+  Default: ``1``
+
+- ``PPC_NUM_THREADS``: Specifies the number of threads to use.
+  Default: ``1``
+
+- ``PPC_ASAN_RUN``: Specifies that application is compiler with sanitizers. Used by ``scripts/run_tests.py`` to skip ``valgrind`` runs.
+  Default: ``0``

--- a/modules/core/util/func_tests/util_tests.cpp
+++ b/modules/core/util/func_tests/util_tests.cpp
@@ -10,11 +10,11 @@ TEST(util_tests, check_unset_env) {
 #ifndef _WIN32
   int save_var = ppc::util::GetPPCNumThreads();
 
-  unsetenv("OMP_NUM_THREADS");  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
+  unsetenv("PPC_NUM_THREADS");  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
 
   EXPECT_EQ(ppc::util::GetPPCNumThreads(), 1);
 
-  setenv("OMP_NUM_THREADS", std::to_string(save_var).c_str(), 1);  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
+  setenv("PPC_NUM_THREADS", std::to_string(save_var).c_str(), 1);  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
 #else
   GTEST_SKIP();
 #endif
@@ -26,11 +26,11 @@ TEST(util_tests, check_set_env) {
 
   const int num_threads = static_cast<int>(std::thread::hardware_concurrency());
   // NOLINTNEXTLINE(concurrency-mt-unsafe,misc-include-cleaner)
-  setenv("OMP_NUM_THREADS", std::to_string(num_threads).c_str(), 1);
+  setenv("PPC_NUM_THREADS", std::to_string(num_threads).c_str(), 1);
 
   EXPECT_EQ(ppc::util::GetPPCNumThreads(), num_threads);
 
-  setenv("OMP_NUM_THREADS", std::to_string(save_var).c_str(), 1);  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
+  setenv("PPC_NUM_THREADS", std::to_string(save_var).c_str(), 1);  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
 #else
   GTEST_SKIP();
 #endif

--- a/modules/core/util/src/util.cpp
+++ b/modules/core/util/src/util.cpp
@@ -20,13 +20,13 @@ int ppc::util::GetPPCNumThreads() {
 #ifdef _WIN32
   size_t len;
   char omp_env[100];
-  errno_t err = getenv_s(&len, omp_env, sizeof(omp_env), "OMP_NUM_THREADS");
+  errno_t err = getenv_s(&len, omp_env, sizeof(omp_env), "PPC_NUM_THREADS");
   if (err != 0 || len == 0) {
     omp_env[0] = '\0';
   }
   int num_threads = std::atoi(omp_env);
 #else
-  const char *omp_env = std::getenv("OMP_NUM_THREADS");  // NOLINT(concurrency-mt-unsafe)
+  const char *omp_env = std::getenv("PPC_NUM_THREADS");  // NOLINT(concurrency-mt-unsafe)
   int num_threads = (omp_env != nullptr) ? std::atoi(omp_env) : 1;
 #endif
   return num_threads;

--- a/scripts/create_perf_table.py
+++ b/scripts/create_perf_table.py
@@ -49,9 +49,9 @@ for table_name in result_tables:
     worksheet.set_column('A:Z', 23)
     right_bold_border = workbook.add_format({'bold': True, 'right': 2, 'bottom': 2})
     bottom_bold_border = workbook.add_format({'bold': True, 'bottom': 2})
-    cpu_num = os.environ.get("PROC_COUNT")
+    cpu_num = os.environ.get("PPC_NUM_PROC")
     if cpu_num is None:
-        raise EnvironmentError("Required environment variable 'PROC_COUNT' is not set.")
+        raise EnvironmentError("Required environment variable 'PPC_NUM_PROC' is not set.")
     cpu_num = int(cpu_num)
     worksheet.write(0, 0, "cpu_num = " + str(cpu_num), right_bold_border)
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -60,7 +60,7 @@ class PPCRunner:
         return command
 
     def run_threads(self):
-        if platform.system() == "Linux" and not os.environ.get("ASAN_RUN"):
+        if platform.system() == "Linux" and not os.environ.get("PPC_ASAN_RUN"):
             self.__run_exec(f"{self.valgrind_cmd} {self.work_dir / 'seq_func_tests'} {self.__get_gtest_settings(1)}")
             self.__run_exec(f"{self.valgrind_cmd} {self.work_dir / 'stl_func_tests'} {self.__get_gtest_settings(1)}")
 
@@ -70,27 +70,27 @@ class PPCRunner:
         self.__run_exec(f"{self.work_dir / 'omp_func_tests'} {self.__get_gtest_settings(3)}")
 
     def run_core(self):
-        if platform.system() == "Linux" and not os.environ.get("ASAN_RUN"):
+        if platform.system() == "Linux" and not os.environ.get("PPC_ASAN_RUN"):
             self.__run_exec(f"{self.valgrind_cmd} {self.work_dir / 'core_func_tests'} {self.__get_gtest_settings(1)}")
 
         self.__run_exec(f"{self.work_dir / 'core_func_tests'} {self.__get_gtest_settings(1)}")
 
     def run_processes(self, additional_mpi_args):
-        proc_count = os.environ.get("PROC_COUNT")
-        if proc_count is None:
-            raise EnvironmentError("Required environment variable 'PROC_COUNT' is not set.")
+        PPC_NUM_PROC = os.environ.get("PPC_NUM_PROC")
+        if PPC_NUM_PROC is None:
+            raise EnvironmentError("Required environment variable 'PPC_NUM_PROC' is not set.")
 
-        mpi_running = f"{self.mpi_exec} {additional_mpi_args} -np {proc_count}"
-        if not os.environ.get("ASAN_RUN"):
+        mpi_running = f"{self.mpi_exec} {additional_mpi_args} -np {PPC_NUM_PROC}"
+        if not os.environ.get("PPC_ASAN_RUN"):
             self.__run_exec(f"{mpi_running} {self.work_dir / 'all_func_tests'} {self.__get_gtest_settings(10)}")
             self.__run_exec(f"{mpi_running} {self.work_dir / 'mpi_func_tests'} {self.__get_gtest_settings(10)}")
 
     def run_performance(self):
-        if not os.environ.get("ASAN_RUN"):
-            proc_count = os.environ.get("PROC_COUNT")
-            if proc_count is None:
-                raise EnvironmentError("Required environment variable 'PROC_COUNT' is not set.")
-            mpi_running = f"{self.mpi_exec} -np {proc_count}"
+        if not os.environ.get("PPC_ASAN_RUN"):
+            PPC_NUM_PROC = os.environ.get("PPC_NUM_PROC")
+            if PPC_NUM_PROC is None:
+                raise EnvironmentError("Required environment variable 'PPC_NUM_PROC' is not set.")
+            mpi_running = f"{self.mpi_exec} -np {PPC_NUM_PROC}"
             self.__run_exec(f"{mpi_running} {self.work_dir / 'all_perf_tests'} {self.__get_gtest_settings(1)}")
             self.__run_exec(f"{mpi_running} {self.work_dir / 'mpi_perf_tests'} {self.__get_gtest_settings(1)}")
 


### PR DESCRIPTION
- Use `PPC_` prefix for all used environment variables
- Add environment variables documentation page