### PR TITLE
Add portable function name helper

### DIFF
--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -109,16 +109,16 @@ class Task {
   /// @brief Validates input data and task attributes before execution.
   /// @return True if validation is successful.
   virtual bool Validation() final {
-    InternalOrderTest(__builtin_FUNCTION());
+    InternalOrderTest(PPC_FUNC_NAME);
     return ValidationImpl();
   }
 
   /// @brief Performs preprocessing on the input data.
   /// @return True if preprocessing is successful.
   virtual bool PreProcessing() final {
-    InternalOrderTest(__builtin_FUNCTION());
+    InternalOrderTest(PPC_FUNC_NAME);
     if (state_of_testing_ == StateOfTesting::kFunc) {
-      InternalTimeTest(__builtin_FUNCTION());
+      InternalTimeTest(PPC_FUNC_NAME);
     }
     return PreProcessingImpl();
   }
@@ -126,16 +126,16 @@ class Task {
   /// @brief Executes the main logic of the task.
   /// @return True if execution is successful.
   virtual bool Run() final {
-    InternalOrderTest(__builtin_FUNCTION());
+    InternalOrderTest(PPC_FUNC_NAME);
     return RunImpl();
   }
 
   /// @brief Performs postprocessing on the output data.
   /// @return True if postprocessing is successful.
   virtual bool PostProcessing() final {
-    InternalOrderTest(__builtin_FUNCTION());
+    InternalOrderTest(PPC_FUNC_NAME);
     if (state_of_testing_ == StateOfTesting::kFunc) {
-      InternalTimeTest(__builtin_FUNCTION());
+      InternalTimeTest(PPC_FUNC_NAME);
     }
     return PostProcessingImpl();
   }

--- a/modules/core/util/include/util.hpp
+++ b/modules/core/util/include/util.hpp
@@ -30,6 +30,12 @@ using NlohmannJsonTypeError = nlohmann::json::type_error;  // NOLINT(misc-includ
 #define INSTANTIATE_TEST_SUITE_P_NOLINT(n, t, g) INSTANTIATE_TEST_SUITE_P(n, t, g)             // NOLINT
 // INSTANTIATE_TEST_SUITE_P | n, t, g, ng == name, test_case_name, generator, name_generator
 
+#if defined(__clang__) || defined(__GNUC__)
+#define PPC_FUNC_NAME __PRETTY_FUNCTION__
+#else
+#define PPC_FUNC_NAME __func__
+#endif
+
 namespace ppc::util {
 
 enum GTestParamIndex : uint8_t { kTaskGetter, kNameTest, kTestParams };

--- a/modules/core/util/include/util.hpp
+++ b/modules/core/util/include/util.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <string_view>
 
+#define PPC_FUNC_NAME __func__
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4459)
@@ -29,12 +31,6 @@ using NlohmannJsonTypeError = nlohmann::json::type_error;  // NOLINT(misc-includ
 #define INSTANTIATE_TEST_SUITE_P_WITH_NAME(n, t, g, ng) INSTANTIATE_TEST_SUITE_P(n, t, g, ng)  // NOLINT
 #define INSTANTIATE_TEST_SUITE_P_NOLINT(n, t, g) INSTANTIATE_TEST_SUITE_P(n, t, g)             // NOLINT
 // INSTANTIATE_TEST_SUITE_P | n, t, g, ng == name, test_case_name, generator, name_generator
-
-#if defined(__clang__) || defined(__GNUC__)
-#define PPC_FUNC_NAME __PRETTY_FUNCTION__
-#else
-#define PPC_FUNC_NAME __func__
-#endif
 
 namespace ppc::util {
 


### PR DESCRIPTION
- Add `PPC_FUNC_NAME` macro providing compiler agnostic pure function name
- Replace `__builtin_FUNCTION()` with `PPC_FUNC_NAME` macro in `task.hpp`