### PR TITLE
Include path in GetStringTaskType error

### DIFF
--- a/modules/core/performance/tests/perf_tests.cpp
+++ b/modules/core/performance/tests/perf_tests.cpp
@@ -167,10 +167,7 @@ TEST_NOLINT(GetStringTaskTypeStandaloneTest, ThrowsIfFileMissing) {
 TEST_NOLINT(GetStringTaskTypeStandaloneTest, ExceptionMessageContainsPath) {
   const std::string missing_path = "non_existent_settings.json";
   EXPECT_THROW(
-      try {
-        GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path);
-      } catch (const std::runtime_error& e) {
-        EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
+      try { GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path); } catch (const std::runtime_error& e) {        EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
         throw;
       },
       std::runtime_error);

--- a/modules/core/performance/tests/perf_tests.cpp
+++ b/modules/core/performance/tests/perf_tests.cpp
@@ -166,7 +166,7 @@ TEST_NOLINT(GetStringTaskTypeStandaloneTest, ThrowsIfFileMissing) {
 
 TEST_NOLINT(GetStringTaskTypeStandaloneTest, ExceptionMessageContainsPath) {
   const std::string missing_path = "non_existent_settings.json";
-  EXPECT_THROW(
+  EXPECT_THROW_NOLINT(
       try { GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path); } catch (const std::runtime_error& e) {
         EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
         throw;

--- a/modules/core/performance/tests/perf_tests.cpp
+++ b/modules/core/performance/tests/perf_tests.cpp
@@ -164,6 +164,18 @@ TEST_NOLINT(GetStringTaskTypeStandaloneTest, ThrowsIfFileMissing) {
   EXPECT_THROW_NOLINT(GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path), std::runtime_error);
 }
 
+TEST_NOLINT(GetStringTaskTypeStandaloneTest, ExceptionMessageContainsPath) {
+  const std::string missing_path = "non_existent_settings.json";
+  EXPECT_THROW(
+      try {
+        GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path);
+      } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
+        throw;
+      },
+      std::runtime_error);
+}
+
 TEST(GetStringTaskTypeStandaloneTest, ReturnsUnknownForInvalidEnum) {
   std::string path = (std::filesystem::temp_directory_path() / "tmp_settings.json").string();
   std::ofstream(path) << R"({"tasks":{"seq":"SEQ"}})";

--- a/modules/core/performance/tests/perf_tests.cpp
+++ b/modules/core/performance/tests/perf_tests.cpp
@@ -167,7 +167,8 @@ TEST_NOLINT(GetStringTaskTypeStandaloneTest, ThrowsIfFileMissing) {
 TEST_NOLINT(GetStringTaskTypeStandaloneTest, ExceptionMessageContainsPath) {
   const std::string missing_path = "non_existent_settings.json";
   EXPECT_THROW(
-      try { GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path); } catch (const std::runtime_error& e) {        EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
+      try { GetStringTaskType(ppc::core::TypeOfTask::kSEQ, missing_path); } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find(missing_path), std::string::npos);
         throw;
       },
       std::runtime_error);

--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -64,7 +64,7 @@ inline std::string GetStringTaskStatus(StatusOfTask status_of_task) {
 inline std::string GetStringTaskType(TypeOfTask type_of_task, const std::string &settings_file_path) {
   std::ifstream file(settings_file_path);
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open file settings.json");
+    throw std::runtime_error("Failed to open " + settings_file_path);
   }
 
   auto list_settings = ppc::util::InitJSONPtr();


### PR DESCRIPTION
- mention the settings file path when GetStringTaskType fails to open the file
- add a unit test validating that the thrown message contains the missing path