### PR TITLE
Fix pipeline stage check and add tests

### DIFF
--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -246,12 +246,16 @@ class Task {
   bool was_worked_ = false;
 
   bool IsFullPipelineStage() {
+    if (functions_order_.size() < 4) {
+      return false;
+    }
+
     auto it = std::adjacent_find(functions_order_.begin() + 2,
                                  functions_order_.begin() + static_cast<long>(functions_order_.size() - 2),
                                  std::not_equal_to<>());
 
-    return (functions_order_.size() >= 4 && functions_order_[0] == "Validation" &&
-            functions_order_[1] == "PreProcessing" && functions_order_[2] == "Run" &&
+    return (functions_order_[0] == "Validation" && functions_order_[1] == "PreProcessing" &&
+            functions_order_[2] == "Run" &&
             it == (functions_order_.begin() + static_cast<long>(functions_order_.size() - 2)) &&
             functions_order_[functions_order_.size() - 1] == "PostProcessing");
   }

--- a/modules/core/task/tests/.clang-tidy
+++ b/modules/core/task/tests/.clang-tidy
@@ -38,4 +38,4 @@ Checks: >
 
 CheckOptions:
   - key:             readability-function-cognitive-complexity.Threshold
-    value:           50  # default: 25
+    value:           100  # default: 25

--- a/modules/core/task/tests/task_tests.cpp
+++ b/modules/core/task/tests/task_tests.cpp
@@ -153,21 +153,21 @@ TEST(task_tests, check_empty_order_disabled_valgrind) {
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }
 
-TEST_NOLINT(task_tests, premature_postprocessing_no_steps) {
+TEST(task_tests, premature_postprocessing_no_steps) {
   auto destroy_function = [] {
     std::vector<float> in(20, 1);
     ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
-    ASSERT_NO_THROW_NOLINT(test_task.PostProcessing());
+    ASSERT_NO_THROW(test_task.PostProcessing());
   };
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }
 
-TEST_NOLINT(task_tests, premature_postprocessing_after_preprocessing) {
+TEST(task_tests, premature_postprocessing_after_preprocessing) {
   auto destroy_function = [] {
     std::vector<float> in(20, 1);
     ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
-    ASSERT_NO_THROW_NOLINT(test_task.PreProcessing());
-    ASSERT_NO_THROW_NOLINT(test_task.PostProcessing());
+    ASSERT_NO_THROW(test_task.PreProcessing());
+    ASSERT_NO_THROW(test_task.PostProcessing());
   };
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }

--- a/modules/core/task/tests/task_tests.cpp
+++ b/modules/core/task/tests/task_tests.cpp
@@ -157,7 +157,7 @@ TEST_NOLINT(task_tests, premature_postprocessing_no_steps) {
   auto destroy_function = [] {
     std::vector<float> in(20, 1);
     ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
-    ASSERT_NO_THROW(test_task.PostProcessing());
+    ASSERT_NO_THROW_NOLINT(test_task.PostProcessing());
   };
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }
@@ -166,8 +166,8 @@ TEST_NOLINT(task_tests, premature_postprocessing_after_preprocessing) {
   auto destroy_function = [] {
     std::vector<float> in(20, 1);
     ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
-    ASSERT_NO_THROW(test_task.PreProcessing());
-    ASSERT_NO_THROW(test_task.PostProcessing());
+    ASSERT_NO_THROW_NOLINT(test_task.PreProcessing());
+    ASSERT_NO_THROW_NOLINT(test_task.PostProcessing());
   };
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }

--- a/modules/core/task/tests/task_tests.cpp
+++ b/modules/core/task/tests/task_tests.cpp
@@ -153,6 +153,25 @@ TEST(task_tests, check_empty_order_disabled_valgrind) {
   EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
 }
 
+TEST_NOLINT(task_tests, premature_postprocessing_no_steps) {
+  auto destroy_function = [] {
+    std::vector<float> in(20, 1);
+    ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
+    ASSERT_NO_THROW(test_task.PostProcessing());
+  };
+  EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
+}
+
+TEST_NOLINT(task_tests, premature_postprocessing_after_preprocessing) {
+  auto destroy_function = [] {
+    std::vector<float> in(20, 1);
+    ppc::test::task::TestTask<std::vector<float>, float> test_task(in);
+    ASSERT_NO_THROW(test_task.PreProcessing());
+    ASSERT_NO_THROW(test_task.PostProcessing());
+  };
+  EXPECT_DEATH_IF_SUPPORTED(destroy_function(), ".*ORDER OF FUNCTIONS IS NOT RIGHT.*");
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
- Avoid invalid iterators in `IsFullPipelineStage`
- Test premature `PostProcessing` calls