### PR TITLE
Remove chrono namespace using directive

### DIFF
--- a/modules/core/task/include/task.hpp
+++ b/modules/core/task/include/task.hpp
@@ -15,7 +15,6 @@
 #include <stdexcept>
 #include <string>
 
-using namespace std::chrono;
 
 namespace ppc::core {
 
@@ -201,7 +200,9 @@ class Task {
     }
 
     if (str == "PostProcessing") {
-      auto duration = duration_cast<nanoseconds>(high_resolution_clock::now() - tmp_time_point_).count();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::high_resolution_clock::now() - tmp_time_point_)
+                            .count();
       auto diff = static_cast<double>(duration) * 1e-9;
 
       std::stringstream err_msg;


### PR DESCRIPTION
## Summary
- remove `using namespace std::chrono` from task header
- explicitly qualify chrono functions

## Testing
- `g++ -std=c++17 -Imodules -I. -I/tmp/stub /tmp/test_compile.cpp -c -o /tmp/test_compile.o`

------
https://chatgpt.com/codex/tasks/task_e_6854f69160a4832fb92e2de613e8b080