### PR TITLE
Fix MPI environment variable list size

### DIFF
--- a/modules/core/util/src/util.cpp
+++ b/modules/core/util/src/util.cpp
@@ -28,7 +28,10 @@ int ppc::util::GetNumThreads() {
   return 1;
 }
 
-constexpr std::array<std::string_view, 13> kMpiEnvVars = {
+// List of environment variables that signal the application is running under
+// an MPI launcher. The array size must match the number of entries to avoid
+// looking up empty environment variable names.
+constexpr std::array<std::string_view, 10> kMpiEnvVars = {
     "OMPI_COMM_WORLD_SIZE", "OMPI_UNIVERSE_SIZE", "PMI_SIZE",     "PMI_RANK",   "PMI_FD",
     "HYDRA_CONTROL_FD",     "PMIX_RANK",          "SLURM_PROCID", "MSMPI_RANK", "MSMPI_LOCALRANK"};
 


### PR DESCRIPTION
## Summary
- fix MPI environment variable list size in util.cpp
- document the array and ensure no empty entries

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68555dc14d648333b32dad97a979606a