### PR TITLE
Remove unused compile definition

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -11,11 +11,6 @@ option(USE_PERF_TESTS "Enable performance tests" OFF)
 set(FUNC_TEST_EXEC ppc_func_tests)
 set(PERF_TEST_EXEC ppc_perf_tests)
 
-# ——— Global compile definitions —————————————————————————————————————
-add_compile_definitions(
-        PATH_TO_PPC_PROJECT="${PROJECT_SOURCE_DIR}"
-)
-
 # ——— Include helper scripts ——————————————————————————————————————
 include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
 


### PR DESCRIPTION
## Summary
- delete unused PATH_TO_PPC_PROJECT compile definition
- confirm that the definition isn't referenced anywhere

## Testing
- `clang-format --dry-run --Werror --assume-filename=temp.cpp tasks/CMakeLists.txt` *(fails: code should be clang-formatted)*
- `flake8 .` *(fails: command not found)*
- `cmake -S . -B build` *(fails: no download info for `ppc_json`)*

------
https://chatgpt.com/codex/tasks/task_e_68594d3ffbc8832f8ce68b97f8f2089c