### PR TITLE
Conditionally apply gtest_force_shared_crt

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -17,7 +17,7 @@ ExternalProject_Add(ppc_googletest
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_C_FLAGS=-w
         -DCMAKE_CXX_FLAGS=-w
-        -Dgtest_force_shared_crt=ON
+        $<$<BOOL:MSVC>:-Dgtest_force_shared_crt=ON>
 
         BUILD_COMMAND     "${CMAKE_COMMAND}" --build "${CMAKE_CURRENT_BINARY_DIR}/ppc_googletest/build" --config ${CMAKE_BUILD_TYPE} --parallel
         INSTALL_COMMAND   "${CMAKE_COMMAND}" --install "${CMAKE_CURRENT_BINARY_DIR}/ppc_googletest/build" --prefix "${CMAKE_CURRENT_BINARY_DIR}/ppc_googletest/install"


### PR DESCRIPTION
## Summary
- enable `gtest_force_shared_crt` only when using MSVC via a generator expression

## Testing
- `python3 -m py_compile scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68594d6f7468832faeb31d436c818353