### PR TITLE
Remove unused runtime flag

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -2,10 +2,6 @@ if(MSVC)
     option(gtest_force_shared_crt "" TRUE)
 endif(MSVC)
 
-if (APPLE)
-    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG TRUE)
-endif(APPLE)
-
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
## Summary
- remove `CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG` from CMake configuration

## Testing
- `python3 -m flake8 .` *(fails: No module named flake8)*
- `python3 scripts/run_tests.py --running-type=threads` *(fails: valgrind missing / build artifacts missing)*

------
https://chatgpt.com/codex/tasks/task_e_68594e8df5c8832fbda554d77d013a21