### PR TITLE
[CI] Introduce shared Windows toolchain setup action

### DIFF
--- a/.github/actions/setup-windows-toolchain/action.yml
+++ b/.github/actions/setup-windows-toolchain/action.yml
@@ -1,0 +1,21 @@
+name: 'Setup Windows Toolchain'
+description: 'Configure msbuild, MPI, ccache, ninja, and MSVC'
+runs:
+  using: 'composite'
+  steps:
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+      with:
+        vs-version: 'latest'
+    - name: Setup MPI
+      uses: mpi4py/setup-mpi@v1
+      with:
+        mpi: msmpi
+    - name: Setup ccache
+      uses: Chocobo1/setup-ccache-action@v1
+      with:
+        windows_compile_environment: msvc
+    - name: Setup ninja
+      uses: seanmiddleditch/gha-setup-ninja@v6
+    - name: Setup MSVC for Ninja again
+      uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,22 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          windows_compile_environment: msvc
-      - name: Setup ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-      - name: Setup MSVC for Ninja again
-        uses: ilammy/msvc-dev-cmd@v1
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: CMake configure
         shell: bash
         run: >
@@ -57,22 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          windows_compile_environment: msvc
-      - name: Setup ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-      - name: Setup MSVC for Ninja again
-        uses: ilammy/msvc-dev-cmd@v1
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: CMake configure
         shell: bash
         run: >
@@ -103,14 +73,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:
@@ -167,14 +130,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:
@@ -211,24 +167,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: Setup LLVM
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "20.1.4"
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          windows_compile_environment: msvc
-      - name: Setup ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
       - name: CMake configure
         run: >
           cmake -S . -B build -G Ninja
@@ -265,14 +208,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:
@@ -309,14 +245,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 'latest'
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
+      - uses: ./.github/actions/setup-windows-toolchain
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
- add `.github/actions/setup-windows-toolchain` composite action
- use this new action in all Windows jobs to configure MSVC and tooling