### PR TITLE
Add shebang and strict mode to perf script

### DIFF
--- a/scripts/generate_perf_results.sh
+++ b/scripts/generate_perf_results.sh
@@ -1,4 +1,5 @@
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 mkdir -p build/perf_stat_dir
 python3 scripts/run_tests.py --running-type="performance" | tee build/perf_stat_dir/perf_log.txt


### PR DESCRIPTION
- add a `#!/usr/bin/env bash` shebang
- enable `set -euo pipefail` for stricter error handling