### PR TITLE
Fix perf result script error handling

### DIFF
--- a/scripts/generate_perf_results.sh
+++ b/scripts/generate_perf_results.sh
@@ -1,4 +1,4 @@
-set -o pipefail
+set -euo pipefail
 
 mkdir -p build/perf_stat_dir
 python3 scripts/run_tests.py --running-type="performance" | tee build/perf_stat_dir/perf_log.txt


### PR DESCRIPTION
## Summary
- update `generate_perf_results.sh` to fail fast on errors or unset variables

## Testing
- `python3 scripts/run_tests.py --running-type=threads` *(fails: Required environment variable 'PPC_NUM_THREADS' is not set)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_685981d1a328832fade35d9a0618f626