### PR TITLE
Allow batch test counts

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -106,46 +106,14 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf macos-clang-sanitizer-install.tar.gz -C install
-      - name: Run func tests (MPI, num_proc=1)
-        run: python3 scripts/run_tests.py --running-type="processes"
+      - name: Run func tests (MPI)
+        run: python3 scripts/run_tests.py --running-type="processes" --counts 1 2 3 4
         env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run func tests (MPI, num_proc=2)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 2
-          PPC_NUM_THREADS: 2
-      - name: Run func tests (MPI, num_proc=3)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 3
           PPC_NUM_THREADS: 1
-      - name: Run func tests (MPI, num_proc=4)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 4
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
   macos-clang-test-extended:
     needs:
       - macos-clang-test
@@ -168,23 +136,7 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf macos-clang-sanitizer-install.tar.gz -C install
-      - name: Run tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-      - name: Run tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-      - name: Run tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-      - name: Run tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -120,46 +120,14 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf ubuntu-gcc-install-${{ matrix.os }}.tar.gz -C install
-      - name: Run func tests (MPI, num_proc=1)
-        run: python3 scripts/run_tests.py --running-type="processes"
+      - name: Run func tests (MPI)
+        run: python3 scripts/run_tests.py --running-type="processes" --counts 1 2 3 4
         env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run func tests (MPI, num_proc=2)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 2
-          PPC_NUM_THREADS: 2
-      - name: Run func tests (MPI, num_proc=3)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 3
           PPC_NUM_THREADS: 1
-      - name: Run func tests (MPI, num_proc=4)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 4
-          PPC_NUM_THREADS: 1
-      - name: Run func tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run func tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run func tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run func tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run func tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
   ubuntu-gcc-test-extended:
     needs:
       - ubuntu-gcc-test
@@ -182,26 +150,10 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf ubuntu-gcc-install-${{ matrix.os }}.tar.gz -C install
-      - name: Run func tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run func tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-      - name: Run func tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-      - name: Run func tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-      - name: Run func tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13
   ubuntu-clang-build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -273,46 +225,14 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf ubuntu-clang-install-${{ matrix.os }}.tar.gz -C install
-      - name: Run func tests (MPI, num_proc=1)
-        run: python3 scripts/run_tests.py --running-type="processes"
+      - name: Run func tests (MPI)
+        run: python3 scripts/run_tests.py --running-type="processes" --counts 1 2 3 4
         env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run func tests (MPI, num_proc=2)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 2
-          PPC_NUM_THREADS: 2
-      - name: Run func tests (MPI, num_proc=3)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 3
           PPC_NUM_THREADS: 1
-      - name: Run func tests (MPI, num_proc=4)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 4
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
   ubuntu-clang-test-extended:
     needs:
       - ubuntu-clang-test
@@ -337,26 +257,10 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf ubuntu-clang-install-${{ matrix.os }}.tar.gz -C install
-      - name: Run tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-      - name: Run tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-      - name: Run tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-      - name: Run tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13
   ubuntu-clang-sanitizer-build:
     needs:
       - ubuntu-clang-build
@@ -435,42 +339,16 @@ jobs:
           mkdir -p install
           tar -xzvf ubuntu-clang-sanitizer-install-${{ matrix.os }}.tar.gz -C install
       - name: Run tests (MPI)
-        run: python3 scripts/run_tests.py --running-type="processes" --additional-mpi-args="--oversubscribe"
+        run: python3 scripts/run_tests.py --running-type="processes" --counts 2 --additional-mpi-args="--oversubscribe"
         env:
-          PPC_NUM_PROC: 2
           PPC_NUM_THREADS: 2
           PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-          PPC_ASAN_RUN: 1
-          ASAN_OPTIONS: abort_on_error=1
-          UBSAN_OPTIONS: halt_on_error=1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-          PPC_ASAN_RUN: 1
-          ASAN_OPTIONS: abort_on_error=1
-          UBSAN_OPTIONS: halt_on_error=1
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-          PPC_ASAN_RUN: 1
-          ASAN_OPTIONS: abort_on_error=1
-          UBSAN_OPTIONS: halt_on_error=1
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
           PPC_ASAN_RUN: 1
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1
@@ -499,29 +377,10 @@ jobs:
         run: |
           mkdir -p install
           tar -xzvf ubuntu-clang-sanitizer-install-${{ matrix.os }}.tar.gz -C install
-      - name: Run tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-          PPC_ASAN_RUN: 1
-      - name: Run tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-          PPC_ASAN_RUN: 1
-      - name: Run tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-          PPC_ASAN_RUN: 1
-      - name: Run tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13
           PPC_ASAN_RUN: 1
   ubuntu-gcc-build-codecov:
     needs:
@@ -557,26 +416,10 @@ jobs:
         env:
           PPC_NUM_PROC: 2
           PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
       - name: Generate gcovr Coverage Data
         run: |
           mkdir cov-report

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,46 +118,14 @@ jobs:
       - name: Extract installed package
         run: Expand-Archive -Path .\windows-msvc-install.zip -DestinationPath . -Force
         shell: pwsh
-      - name: Run func tests (MPI, num_proc=1)
-        run: python3 scripts/run_tests.py --running-type="processes"
+      - name: Run func tests (MPI)
+        run: python3 scripts/run_tests.py --running-type="processes" --counts 1 2 3 4
         env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run func tests (MPI, num_proc=2)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 2
-          PPC_NUM_THREADS: 2
-      - name: Run func tests (MPI, num_proc=3)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 3
           PPC_NUM_THREADS: 1
-      - name: Run func tests (MPI, num_proc=4)
-        run: python3 scripts/run_tests.py --running-type="processes"
-        env:
-          PPC_NUM_PROC: 4
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
   windows-msvc-test-extended:
     needs:
       - windows-msvc-test
@@ -182,26 +150,10 @@ jobs:
       - name: Extract installed package
         run: Expand-Archive -Path .\windows-msvc-install.zip -DestinationPath . -Force
         shell: pwsh
-      - name: Run tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-      - name: Run tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-      - name: Run tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-      - name: Run tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13
   windows-clang-build:
     runs-on: windows-latest
     defaults:
@@ -280,26 +232,10 @@ jobs:
       - name: Extract installed package
         run: Expand-Archive -Path .\windows-clang-install.zip -DestinationPath . -Force
         shell: pwsh
-      - name: Run tests (threads, num_threads=1)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 1 2 3 4
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 1
-      - name: Run tests (threads, num_threads=2)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 2
-      - name: Run tests (threads, num_threads=3)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 3
-      - name: Run tests (threads, num_threads=4)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 4
   windows-clang-test-extended:
     needs:
       - windows-clang-test
@@ -324,23 +260,7 @@ jobs:
       - name: Extract installed package
         run: Expand-Archive -Path .\windows-clang-install.zip -DestinationPath . -Force
         shell: pwsh
-      - name: Run tests (threads, num_threads=5)
-        run: python3 scripts/run_tests.py --running-type="threads"
+      - name: Run tests (threads extended)
+        run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:
           PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 5
-      - name: Run tests (threads, num_threads=7)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 7
-      - name: Run tests (threads, num_threads=11)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 11
-      - name: Run tests (threads, num_threads=13)
-        run: python3 scripts/run_tests.py --running-type="threads"
-        env:
-          PPC_NUM_PROC: 1
-          PPC_NUM_THREADS: 13


### PR DESCRIPTION
- Extend `run_tests.py` to accept a list of counts and loop internally
- Collapse repeated CI test steps in workflow files by providing all counts in a single call
- Refactor main logic in `run_tests.py` into a helper to remove duplication
- Print each count before execution in batch mode