### PR TITLE
[CI] Introduce build type matrix workflows

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -4,6 +4,9 @@ on:
 jobs:
   macos-clang-build:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +35,7 @@ jobs:
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_C_FLAGS="-I$(brew --prefix)/opt/libomp/include"
           -DCMAKE_CXX_FLAGS="-I$(brew --prefix)/opt/libomp/include"
-          -D CMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
       - name: Build project
         run: |
           cmake --build build --parallel
@@ -43,49 +46,7 @@ jobs:
         uses: ./.github/actions/archive-install
         with:
           path: install
-          name: macos-clang-sanitizer-install
-  macos-clang-build-debug:
-    runs-on: macOS-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Install Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 'latest-stable'
-      - name: Setup environment
-        run: |
-          brew update-reset
-          brew install ninja mpich llvm
-          brew install libomp
-          brew link libomp --overwrite --force
-          brew install openssl
-          brew link openssl --overwrite --force
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ runner.os }}-clang
-          create-symlink: true
-          max-size: 1G
-      - name: CMake configure
-        run: >
-          cmake -S . -B build -G Ninja
-          -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -DCMAKE_C_FLAGS="-I$(brew --prefix)/opt/libomp/include"
-          -DCMAKE_CXX_FLAGS="-I$(brew --prefix)/opt/libomp/include"
-          -D CMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=install
-      - name: Build project
-        run: |
-          cmake --build build --parallel
-      - name: Install project
-        run: |
-          cmake --build build --target install
-      - name: Archive installed package
-        uses: ./.github/actions/archive-install
-        with:
-          path: install
-          name: macos-clang-debug-install
+          name: ${{ matrix.build_type == 'Debug' && 'macos-clang-debug-install' || 'macos-clang-install' }}
   macos-clang-test:
     needs:
       - macos-clang-build
@@ -107,11 +68,11 @@ jobs:
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:
-          name: macos-clang-sanitizer-install
+          name: macos-clang-install
       - name: Extract installed package
         run: |
           mkdir -p install
-          tar -xzvf macos-clang-sanitizer-install.tar.gz -C install
+          tar -xzvf macos-clang-install.tar.gz -C install
       - name: Run func tests (MPI)
         run: python3 scripts/run_tests.py --running-type="processes" --counts 1 2 3 4
         env:
@@ -141,11 +102,11 @@ jobs:
       - name: Download installed package
         uses: actions/download-artifact@v4
         with:
-          name: macos-clang-sanitizer-install
+          name: macos-clang-install
       - name: Extract installed package
         run: |
           mkdir -p install
-          tar -xzvf macos-clang-sanitizer-install.tar.gz -C install
+          tar -xzvf macos-clang-install.tar.gz -C install
       - name: Run tests (threads extended)
         run: python3 scripts/run_tests.py --running-type="threads" --counts 5 7 11 13
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        build_type: [Release, Debug]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,13 +27,13 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
         env:
           CC: gcc-14
           CXX: g++-14
       - name: Archive revert list
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.build_type == 'Release' }}
         with:
           name: revert-list
           path: build/revert-list.txt
@@ -49,49 +50,9 @@ jobs:
         uses: ./.github/actions/archive-install
         with:
           path: install
-          name: ubuntu-gcc-install-${{ matrix.os }}
-  ubuntu-gcc-build-debug:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["ubuntu-24.04"]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y gcc-14 g++-14 ninja-build libmpich-dev libomp-dev valgrind
-          python3 -m pip install -r requirements.txt
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ runner.os }}-gcc
-          create-symlink: true
-          max-size: 1G
-      - name: CMake configure
-        run: >
-          cmake -S . -B build -G Ninja
-          -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=install
-        env:
-          CC: gcc-14
-          CXX: g++-14
-      - name: Build project
-        run: |
-          cmake --build build --parallel
-        env:
-          CC: gcc-14
-          CXX: g++-14
-      - name: Install project
-        run: |
-          cmake --build build --target install
-      - name: Archive installed package
-        uses: ./.github/actions/archive-install
-        with:
-          path: install
-          name: ubuntu-gcc-debug-install-${{ matrix.os }}
+          name: ${{ matrix.build_type == 'Debug' &&
+            format('ubuntu-gcc-debug-install-{0}', matrix.os) ||
+            format('ubuntu-gcc-install-{0}', matrix.os) }}
   ubuntu-gcc-test:
     needs:
       - ubuntu-gcc-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,9 @@ on:
 jobs:
   windows-msvc-build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
     defaults:
       run:
         shell: bash
@@ -17,11 +20,11 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja -D CMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
       - name: Build project
         shell: bash
         run: |
-          cmake --build build --config Release --parallel
+          cmake --build build --config ${{ matrix.build_type }} --parallel
       - name: Install project
         run: |
           cmake --build build --target install
@@ -29,35 +32,7 @@ jobs:
         uses: ./.github/actions/archive-install
         with:
           path: install
-          name: windows-msvc-install
-  windows-msvc-build-debug:
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-windows-toolchain
-      - name: CMake configure
-        shell: bash
-        run: >
-          cmake -S . -B build -G Ninja -D CMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
-          -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=install
-      - name: Build project
-        shell: bash
-        run: |
-          cmake --build build --config Debug --parallel
-      - name: Install project
-        run: |
-          cmake --build build --target install
-      - name: Archive installed package
-        uses: ./.github/actions/archive-install
-        with:
-          path: install
-          name: windows-msvc-debug-install
+          name: ${{ matrix.build_type == 'Debug' && 'windows-msvc-debug-install' || 'windows-msvc-install' }}
   windows-msvc-test:
     needs:
       - windows-msvc-build


### PR DESCRIPTION
- consolidate build and debug jobs using a `build_type` matrix
- set `CMAKE_BUILD_TYPE` from the matrix variable
- name uploaded artifacts based on the build type
- fix macOS artifact naming
