### PR TITLE
Use RelWithDebInfo for sanitizers, document build types

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type == 'Release' && 'RelWithDebInfo' || matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
         env:
           CC: gcc-14
           CXX: g++-14
@@ -135,7 +135,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
         env:
           CC: clang-20
           CXX: clang++-20
@@ -242,7 +242,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RELEASE
+          -D CMAKE_BUILD_TYPE=RelWithDebInfo
           -D ENABLE_ADDRESS_SANITIZER=ON -D ENABLE_UB_SANITIZER=ON -D ENABLE_LEAK_SANITIZER=ON
           -D CMAKE_INSTALL_PREFIX=install
         env:
@@ -355,7 +355,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RELEASE
+          -D CMAKE_BUILD_TYPE=RelWithDebInfo
           -D CMAKE_VERBOSE_MAKEFILE=ON -D USE_COVERAGE=ON
       - name: Build project
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=${{ matrix.build_type == 'Release' && 'RelWithDebInfo' || matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=install
         env:
           CC: gcc-14
           CXX: g++-14
@@ -135,7 +135,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+          -D CMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=install
         env:
           CC: clang-20
           CXX: clang++-20
@@ -355,7 +355,7 @@ jobs:
         run: >
           cmake -S . -B build -G Ninja
           -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -D CMAKE_BUILD_TYPE=RelWithDebInfo
+          -D CMAKE_BUILD_TYPE=RELEASE
           -D CMAKE_VERBOSE_MAKEFILE=ON -D USE_COVERAGE=ON
       - name: Build project
         run: |

--- a/docs/locale/en/LC_MESSAGES/user_guide/build.po
+++ b/docs/locale/en/LC_MESSAGES/user_guide/build.po
@@ -45,9 +45,15 @@ msgid "``-D USE_PERF_TESTS=ON`` enable performance tests."
 msgstr ""
 
 #: ../../user_guide/build.rst:22
-msgid ""
-"``-D CMAKE_BUILD_TYPE=Release`` required parameter for stable work of "
-"repo."
+msgid "``-D CMAKE_BUILD_TYPE=Release`` normal build (default)."
+msgstr ""
+
+#: ../../user_guide/build.rst:23
+msgid "``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers or running ``valgrind`` to keep debug information."
+msgstr ""
+
+#: ../../user_guide/build.rst:24
+msgid "``-D CMAKE_BUILD_TYPE=Debug`` for debugging sessions."
 msgstr ""
 
 #: ../../user_guide/build.rst:24

--- a/docs/locale/ru/LC_MESSAGES/user_guide/build.po
+++ b/docs/locale/ru/LC_MESSAGES/user_guide/build.po
@@ -46,12 +46,16 @@ msgid "``-D USE_PERF_TESTS=ON`` enable performance tests."
 msgstr "``-D USE_PERF_TESTS=ON`` включает тесты на производительность."
 
 #: ../../user_guide/build.rst:22
-msgid ""
-"``-D CMAKE_BUILD_TYPE=Release`` required parameter for stable work of "
-"repo."
-msgstr ""
-"``-D CMAKE_BUILD_TYPE=Release`` требуемый CMake параметр для стабильной работы "
-"репозитория."
+msgid "``-D CMAKE_BUILD_TYPE=Release`` normal build (default)."
+msgstr "``-D CMAKE_BUILD_TYPE=Release`` нормальная сборка (по умолчанию)."
+
+#: ../../user_guide/build.rst:23
+msgid "``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers or running ``valgrind`` to keep debug information."
+msgstr "``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` рекомендуется при использовании санитайзеров или запуске ``valgrind`` для сохранения отладочной информации."
+
+#: ../../user_guide/build.rst:24
+msgid "``-D CMAKE_BUILD_TYPE=Debug`` for debugging sessions."
+msgstr "``-D CMAKE_BUILD_TYPE=Debug`` используется при отладке."
 
 #: ../../user_guide/build.rst:24
 msgid "*A corresponding flag can be omitted if it's not needed.*"

--- a/docs/user_guide/build.rst
+++ b/docs/user_guide/build.rst
@@ -15,7 +15,10 @@ Navigate to a source code folder.
 
    - ``-D USE_FUNC_TESTS=ON`` enable functional tests.
    - ``-D USE_PERF_TESTS=ON`` enable performance tests.
-   - ``-D CMAKE_BUILD_TYPE=Release`` required parameter for stable work of repo.
+   - ``-D CMAKE_BUILD_TYPE=Release`` normal build (default).
+   - ``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers or
+     running ``valgrind`` to keep debug information.
+   - ``-D CMAKE_BUILD_TYPE=Debug`` for debugging sessions.
 
    *A corresponding flag can be omitted if it's not needed.*
 


### PR DESCRIPTION
- Build sanitizer tests with RelWithDebInfo
- Document that RelWithDebInfo is recommended for sanitizers/valgrind