### PR TITLE
Enable 'modernize-loop-convert' clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,6 @@ Checks: >
   -misc-const-correctness,
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
-  -modernize-loop-convert,
   -modernize-use-trailing-return-type,
   -portability-template-virtual-member-function,
   -readability-magic-numbers


### PR DESCRIPTION
Since OpenMP 4.0+ is enforced for all platforms this check can be applied
