### PR TITLE
[doc] Use Google-hosted PT Sans for Russian docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap');
+
+html[lang="ru"] body {
+    font-family: 'PT Sans', Arial, sans-serif;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,3 +48,8 @@ html_theme_options = {
     "collapse_navigation": False,
     "navigation_depth": 2,
 }
+
+
+def setup(app):
+    """Add custom CSS files."""
+    app.add_css_file("custom.css")


### PR DESCRIPTION
- import PT Sans from Google Fonts in custom CSS for `/ru` docs
- keep Sphinx setup that loads this stylesheet
