### PR TITLE
Remove namespace directives from util headers

### DIFF
--- a/modules/util/include/func_test_util.hpp
+++ b/modules/util/include/func_test_util.hpp
@@ -16,12 +16,10 @@
 #include "task/include/task.hpp"
 #include "util/include/util.hpp"
 
-using namespace ppc::task;
-
 namespace ppc::util {
 
 template <typename InType, typename OutType, typename TestType = void>
-using FuncTestParam = std::tuple<std::function<TaskPtr<InType, OutType>(InType)>, std::string, TestType>;
+using FuncTestParam = std::tuple<std::function<ppc::task::TaskPtr<InType, OutType>(InType)>, std::string, TestType>;
 
 template <typename InType, typename OutType, typename TestType = void>
 using GTestFuncParam = ::testing::TestParamInfo<FuncTestParam<InType, OutType, TestType>>;
@@ -98,7 +96,7 @@ class BaseRunFuncTests : public ::testing::TestWithParam<FuncTestParam<InType, O
   }
 
  private:
-  TaskPtr<InType, OutType> task_;
+  ppc::task::TaskPtr<InType, OutType> task_;
 };
 
 template <typename Tuple, std::size_t... Is>
@@ -115,10 +113,10 @@ auto ExpandToValues(const Tuple& t) {
 template <typename Task, typename InType, typename SizesContainer, std::size_t... Is>
 auto GenTaskTuplesImpl(const SizesContainer& sizes, const std::string& settings_path,
                        std::index_sequence<Is...> /*unused*/) {
-  return std::make_tuple(std::make_tuple(
-      TaskGetter<Task, InType>,
-      std::string(GetNamespace<Task>()) + "_" + GetStringTaskType(Task::GetStaticTypeOfTask(), settings_path),
-      sizes[Is])...);
+  return std::make_tuple(std::make_tuple(ppc::task::TaskGetter<Task, InType>,
+                                         std::string(GetNamespace<Task>()) + "_" +
+                                             ppc::task::GetStringTaskType(Task::GetStaticTypeOfTask(), settings_path),
+                                         sizes[Is])...);
 }
 
 template <typename Task, typename InType, typename SizesContainer>


### PR DESCRIPTION

- drop `using namespace ppc::task` from func/perf test headers
- drop `using namespace ppc::performance` from perf test header
- qualify names in util helpers with their namespaces