### PR TITLE
Add env-based time limits

### DIFF
--- a/docs/user_guide/environment_variables.rst
+++ b/docs/user_guide/environment_variables.rst
@@ -14,3 +14,7 @@ The following environment variables can be used to configure the project's runti
 
 - ``PPC_IGNORE_TEST_TIME_LIMIT``: Specifies that test time limits are ignored. Used by ``scripts/run_tests.py`` to disable time limit enforcement.
   Default: ``0``
+- ``PPC_TASK_MAX_TIME``: Maximum allowed execution time in seconds for functional tests.
+  Default: ``1.0``
+- ``PPC_PERF_MAX_TIME``: Maximum allowed execution time in seconds for performance tests.
+  Default: ``10.0``

--- a/modules/performance/include/performance.hpp
+++ b/modules/performance/include/performance.hpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <util/include/util.hpp>
 
 #include "task/include/task.hpp"
 

--- a/modules/performance/include/performance.hpp
+++ b/modules/performance/include/performance.hpp
@@ -78,14 +78,15 @@ class Perf {
     }
 
     auto time_secs = perf_results_.time_sec;
+    const auto max_time = ppc::util::GetPerfMaxTime();
     std::stringstream perf_res_str;
-    if (time_secs < PerfResults::kMaxTime) {
+    if (time_secs < max_time) {
       perf_res_str << std::fixed << std::setprecision(10) << time_secs;
       std::cout << test_id << ":" << type_test_name << ":" << perf_res_str.str() << '\n';
     } else {
       std::stringstream err_msg;
       err_msg << '\n' << "Task execute time need to be: ";
-      err_msg << "time < " << PerfResults::kMaxTime << " secs." << '\n';
+      err_msg << "time < " << max_time << " secs." << '\n';
       err_msg << "Original time in secs: " << time_secs << '\n';
       perf_res_str << std::fixed << std::setprecision(10) << -1.0;
       std::cout << test_id << ":" << type_test_name << ":" << perf_res_str.str() << '\n';

--- a/modules/task/include/task.hpp
+++ b/modules/task/include/task.hpp
@@ -215,12 +215,13 @@ class Task {
                           .count();
       auto diff = static_cast<double>(duration) * 1e-9;
 
+      const auto max_time = ppc::util::GetTaskMaxTime();
       std::stringstream err_msg;
-      if (diff < kMaxTestTime) {
+      if (diff < max_time) {
         err_msg << "Test time:" << std::fixed << std::setprecision(10) << diff << '\n';
       } else {
         err_msg << "\nTask execute time need to be: ";
-        err_msg << "time < " << kMaxTestTime << " secs.\n";
+        err_msg << "time < " << max_time << " secs.\n";
         err_msg << "Original time in secs: " << diff << '\n';
         throw std::runtime_error(err_msg.str().c_str());
       }
@@ -249,7 +250,6 @@ class Task {
   StateOfTesting state_of_testing_ = kFunc;
   TypeOfTask type_of_task_ = kUnknown;
   StatusOfTask status_of_task_ = kEnabled;
-  static constexpr double kMaxTestTime = 1.0;
   std::chrono::high_resolution_clock::time_point tmp_time_point_;
   enum class PipelineStage : uint8_t {
     kNone,

--- a/modules/util/include/util.hpp
+++ b/modules/util/include/util.hpp
@@ -52,6 +52,8 @@ enum GTestParamIndex : uint8_t { kTaskGetter, kNameTest, kTestParams };
 
 std::string GetAbsoluteTaskPath(const std::string& id_path, const std::string& relative_path);
 int GetNumThreads();
+double GetTaskMaxTime();
+double GetPerfMaxTime();
 
 template <typename T>
 std::string GetNamespace() {

--- a/modules/util/src/util.cpp
+++ b/modules/util/src/util.cpp
@@ -28,6 +28,22 @@ int ppc::util::GetNumThreads() {
   return 1;
 }
 
+double ppc::util::GetTaskMaxTime() {
+  const auto val = env::get<double>("PPC_TASK_MAX_TIME");
+  if (val.has_value()) {
+    return val.value();
+  }
+  return 1.0;
+}
+
+double ppc::util::GetPerfMaxTime() {
+  const auto val = env::get<double>("PPC_PERF_MAX_TIME");
+  if (val.has_value()) {
+    return val.value();
+  }
+  return 10.0;
+}
+
 // List of environment variables that signal the application is running under
 // an MPI launcher. The array size must match the number of entries to avoid
 // looking up empty environment variable names.


### PR DESCRIPTION
- read optional env vars `PPC_TASK_MAX_TIME` and `PPC_PERF_MAX_TIME`
- use those env vars when checking execution time
- document new environment variables