### PR TITLE
Ensure test cleanup via RAII

### DIFF
--- a/modules/task/tests/task_tests.cpp
+++ b/modules/task/tests/task_tests.cpp
@@ -20,7 +20,7 @@ using namespace ppc::task;
 
 class ScopedFile {
  public:
-  explicit ScopedFile(const std::string& path) : path_(path) {}
+  explicit ScopedFile(std::string path) : path_(std::move(path)) {}
   ~ScopedFile() {
     std::error_code ec;
     std::filesystem::remove(path_, ec);

--- a/modules/task/tests/task_tests.cpp
+++ b/modules/task/tests/task_tests.cpp
@@ -4,9 +4,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <stdexcept>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -15,6 +17,18 @@
 #include "util/include/util.hpp"
 
 using namespace ppc::task;
+
+class ScopedFile {
+ public:
+  explicit ScopedFile(const std::string& path) : path_(path) {}
+  ~ScopedFile() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+
+ private:
+  std::string path_;
+};
 
 namespace ppc::test {
 
@@ -132,6 +146,7 @@ TEST(TaskTest, GetStringTaskType_InvalidFileThrows) {
 
 TEST(TaskTest, GetStringTaskType_UnknownType_WithValidFile) {
   std::string path = "settings_valid.json";
+  ScopedFile cleaner(path);
   std::ofstream file(path);
   file
       << R"({"tasks": {"all": "enabled", "stl": "enabled", "omp": "enabled", "mpi": "enabled", "tbb": "enabled", "seq": "enabled"}})";
@@ -141,6 +156,7 @@ TEST(TaskTest, GetStringTaskType_UnknownType_WithValidFile) {
 
 TEST(TaskTest, GetStringTaskType_ThrowsOnBadJSON) {
   std::string path = "bad_settings.json";
+  ScopedFile cleaner(path);
   std::ofstream file(path);
   file << "{";
   file.close();
@@ -149,6 +165,7 @@ TEST(TaskTest, GetStringTaskType_ThrowsOnBadJSON) {
 
 TEST(TaskTest, GetStringTaskType_EachType_WithValidFile) {
   std::string path = "settings_valid_all.json";
+  ScopedFile cleaner(path);
   std::ofstream file(path);
   file
       << R"({"tasks": {"all": "enabled", "stl": "enabled", "omp": "enabled", "mpi": "enabled", "tbb": "enabled", "seq": "enabled"}})";
@@ -164,6 +181,7 @@ TEST(TaskTest, GetStringTaskType_EachType_WithValidFile) {
 
 TEST(TaskTest, GetStringTaskType_ReturnsUnknown_OnDefault) {
   std::string path = "settings_valid_unknown.json";
+  ScopedFile cleaner(path);
   std::ofstream file(path);
   file << R"({"tasks": {"all": "enabled"}})";
   file.close();
@@ -174,6 +192,7 @@ TEST(TaskTest, GetStringTaskType_ReturnsUnknown_OnDefault) {
 
 TEST(TaskTest, GetStringTaskType_ThrowsIfKeyMissing) {
   std::string path = "settings_partial.json";
+  ScopedFile cleaner(path);
   std::ofstream file(path);
   file << R"({"tasks": {"all": "enabled"}})";
   file.close();

--- a/modules/task/tests/task_tests.cpp
+++ b/modules/task/tests/task_tests.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <system_error>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "runners/include/runners.hpp"

--- a/modules/task/tests/task_tests.cpp
+++ b/modules/task/tests/task_tests.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <system_error>
 #include <thread>
 #include <utility>


### PR DESCRIPTION
- add a `ScopedFile` RAII helper for test files
- remove any temporary files in `task_tests.cpp`