### PR TITLE
Capture MPI_Iprobe errors

### DIFF
--- a/modules/runners/src/runners.cpp
+++ b/modules/runners/src/runners.cpp
@@ -24,7 +24,11 @@ void UnreadMessagesDetector::OnTestEnd(const ::testing::TestInfo& /*test_info*/)
   int flag = -1;
   MPI_Status status;
 
-  MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, &status);
+  const int iprobe_res = MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, &status);
+  if (iprobe_res != MPI_SUCCESS) {
+    std::cerr << std::format("[  PROCESS {}  ] [  ERROR  ] MPI_Iprobe failed with code {}", rank, iprobe_res) << '\n';
+    MPI_Abort(MPI_COMM_WORLD, iprobe_res);
+  }
 
   if (flag != 0) {
     std::cerr


### PR DESCRIPTION
## Summary
- handle return value from `MPI_Iprobe` in `UnreadMessagesDetector`

## Testing
- `pre-commit run --files modules/runners/src/runners.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686a6373e2bc832fbeae9af1495e0525