### PR TITLE
Add verbose option to run_tests.py

### DIFF
--- a/docs/user_guide/ci.rst
+++ b/docs/user_guide/ci.rst
@@ -56,3 +56,12 @@ Example usage:
 
 Additional MPI arguments can be supplied with ``--additional-mpi-args`` when
 running in ``processes`` mode.
+
+The ``--counts`` option allows sequential execution of tests with several
+thread/process counts.  When specified, the script will iterate over the provided
+values, updating ``PPC_NUM_THREADS`` or ``PPC_NUM_PROC`` accordingly before each
+run.
+
+Use ``--verbose`` to print every command executed by ``run_tests.py``.  This can
+be helpful for debugging CI failures or verifying the exact arguments passed to
+the test binaries.

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -28,17 +28,23 @@ def init_cmd_args():
         type=int,
         help="List of process/thread counts to run sequentially"
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print commands executed by the script"
+    )
     args = parser.parse_args()
     _args_dict = vars(args)
     return _args_dict
 
 
 class PPCRunner:
-    def __init__(self):
+    def __init__(self, verbose=False):
         self.__ppc_num_threads = None
         self.__ppc_num_proc = None
         self.__ppc_env = None
         self.work_dir = None
+        self.verbose = verbose
 
         self.valgrind_cmd = "valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all"
 
@@ -71,6 +77,8 @@ class PPCRunner:
             self.work_dir = Path(self.__get_project_path()) / "build" / "bin"
 
     def __run_exec(self, command):
+        if self.verbose:
+            print("Executing:", " ".join(shlex.quote(part) for part in command))
         result = subprocess.run(command, shell=False, env=self.__ppc_env)
         if result.returncode != 0:
             raise Exception(f"Subprocess return {result.returncode}.")
@@ -144,7 +152,7 @@ class PPCRunner:
 
 
 def _execute(args_dict, env):
-    runner = PPCRunner()
+    runner = PPCRunner(verbose=args_dict.get("verbose", False))
     runner.setup_env(env)
 
     if args_dict["running_type"] in ["threads", "processes"]:


### PR DESCRIPTION
## Summary
- add `--verbose` flag to scripts/run_tests.py to print executed commands
- document `--verbose` and `--counts` usage in the CI guide

## Testing
- `flake8 scripts/run_tests.py`
- `python3 -m py_compile scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6879ff427374832fa7ac3ac329663407