### PR TITLE
Refactor scoreboard to use Jinja templates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==2.2.3
 XlsxWriter==3.2.5
 PyYAML==6.0.2
 pre-commit==4.2.0
+Jinja2==3.1.3

--- a/scoreboard/main.py
+++ b/scoreboard/main.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import argparse
 import yaml
 import csv
+from jinja2 import Environment, FileSystemLoader
 
 task_types = ['all', 'mpi', 'omp', 'seq', 'stl', 'tbb']
 
@@ -33,40 +34,7 @@ with open(plagiarism_config_path, 'r') as file:
     plagiarism_cfg = yaml.safe_load(file)
 assert plagiarism_cfg, "Plagiarism configuration is empty"
 
-columns = ''.join(['<th colspan=5 style="text-align: center;">' + task_type + '</th>' for task_type in task_types])
-html_content = f"""
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Task Directories</title>
-    <link rel="stylesheet" type="text/css" href="static/main.css">
-</head>
-<body>
-    <h1>Scoreboard</h1>
-    <h3 style="color: red;">Note:</b> This is experimental and results are for reference only!</h3>
-    <p>
-        <b>(S)olution</b> - The correctness and completeness of the implemented solution.<br/>
-        <b>(A)cceleration</b> - The process of speeding up software to improve performance.
-        Speedup = T(seq) / T(parallel)<br/>
-        <b>(E)fficiency</b> - Optimizing software speed-up by improving CPU utilization and resource management.
-        Efficiency = Speedup / NumProcs * 100%<br/>
-        <b>(D)eadline</b> - The timeliness of the submission in relation to the given deadline.<br/>
-        <b>(P)lagiarism</b> - The originality of the work, ensuring no copied content from external sources.<br/>
-    </p>
-    <table>
-        <tr>
-            <th rowspan=2>Tasks</th>
-            {columns}
-            <th rowspan=2>Total</th>
-        </tr>
-        <tr>
-            {''.join([
-                f'<th style="text-align: center;">{letter}</th>'
-                for _ in range(len(task_types))
-                for letter in ('S', 'A', 'E', 'D', 'P')
-            ])}
-        </tr>
-"""
+env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
 
 
 perf_stat_file_path = Path(__file__).parent.parent / "build" / "perf_stat_dir" / "task_run_perf_table.csv"
@@ -88,48 +56,48 @@ if perf_stat_file_path.exists():
 else:
     print(f"Warning: Performance stats CSV not found at {perf_stat_file_path}")
 
-
+rows = []
 for dir in sorted(directories.keys()):
-    html_content += f"<tr><td>{dir}</td>"
+    row_types = []
     total_count = 0
     for task_type in task_types:
         max_sol_points = int(cfg["scoreboard"]["task"][task_type]["solution"]["max"])
-        task_count = 0
-        if directories[dir].get(task_type) == "done":
-            html_content += f'<td style="text-align: center;background-color: lightgreen;">{max_sol_points}</td>'
-            task_count += max_sol_points
-        elif directories[dir].get(task_type) == "disabled":
-            html_content += f'<td style="text-align: center;background-color: #6495ED;">{max_sol_points}</td>'
-            task_count += max_sol_points
-        else:
-            html_content += '<td style="text-align: center;">0</td>'
-        html_content += '<td style="text-align: center;background-color: lavender;">'
-        if dir in perf_stats.keys():
-            html_content += perf_stats[dir][task_type]
-        else:
-            html_content += '?'
-        html_content += '</td>'
-        html_content += '<td style="text-align: center;background-color: lavender;">0</td>'
-        html_content += '<td style="text-align: center;">0</td>'
-        is_cheated = \
-            dir in plagiarism_cfg["plagiarism"][task_type] or \
-            dir[:-len("_disabled")] in plagiarism_cfg["plagiarism"][task_type]
+        status = directories[dir].get(task_type)
+        sol_points = max_sol_points if status in ("done", "disabled") else 0
+        solution_style = ""
+        if status == "done":
+            solution_style = "background-color: lightgreen;"
+        elif status == "disabled":
+            solution_style = "background-color: #6495ED;"
+
+        task_points = sol_points
+        is_cheated = (
+            dir in plagiarism_cfg["plagiarism"][task_type]
+            or dir.rstrip("_disabled") in plagiarism_cfg["plagiarism"][task_type]
+        )
+        plagiarism_points = 0
         if is_cheated:
             plag_coeff = float(cfg["scoreboard"]["plagiarism"]["coefficient"])
-            plagiarism_points = -plag_coeff * task_count
-            task_count += plagiarism_points
-            html_content += f'<td style="text-align: center; background-color: pink;">{plagiarism_points}</td>'
-        else:
-            html_content += '<td style="text-align: center;">0</td>'
-        total_count += task_count
-    html_content += f'<td style="text-align: center;">{total_count}</td>'
-    html_content += "</tr>"
+            plagiarism_points = -plag_coeff * task_points
+            task_points += plagiarism_points
 
-html_content += """
-    </table>
-</body>
-</html>
-"""
+        perf_val = perf_stats.get(dir, {}).get(task_type, "?")
+
+        row_types.append(
+            {
+                "solution_points": sol_points,
+                "solution_style": solution_style,
+                "perf": perf_val,
+                "plagiarised": is_cheated,
+                "plagiarism_points": plagiarism_points,
+            }
+        )
+        total_count += task_points
+
+    rows.append({"task": dir, "types": row_types, "total": total_count})
+
+template = env.get_template("index.html.j2")
+html_content = template.render(task_types=task_types, rows=rows)
 
 parser = argparse.ArgumentParser(description='Generate HTML scoreboard.')
 parser.add_argument('-o', '--output', type=str, required=True, help='Output file path')

--- a/scoreboard/templates/index.html.j2
+++ b/scoreboard/templates/index.html.j2
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Task Directories</title>
+    <link rel="stylesheet" type="text/css" href="static/main.css">
+</head>
+<body>
+    <h1>Scoreboard</h1>
+    <h3 style="color: red;">Note:</b> This is experimental and results are for reference only!</h3>
+    <p>
+        <b>(S)olution</b> - The correctness and completeness of the implemented solution.<br/>
+        <b>(A)cceleration</b> - The process of speeding up software to improve performance.
+        Speedup = T(seq) / T(parallel)<br/>
+        <b>(E)fficiency</b> - Optimizing software speed-up by improving CPU utilization and resource management.
+        Efficiency = Speedup / NumProcs * 100%<br/>
+        <b>(D)eadline</b> - The timeliness of the submission in relation to the given deadline.<br/>
+        <b>(P)lagiarism</b> - The originality of the work, ensuring no copied content from external sources.<br/>
+    </p>
+    <table>
+        <tr>
+            <th rowspan="2">Tasks</th>
+            {% for type in task_types %}
+                <th colspan="5" style="text-align: center;">{{ type }}</th>
+            {% endfor %}
+            <th rowspan="2">Total</th>
+        </tr>
+        <tr>
+            {% for type in task_types %}
+                {% for letter in ('S', 'A', 'E', 'D', 'P') %}
+                    <th style="text-align: center;">{{ letter }}</th>
+                {% endfor %}
+            {% endfor %}
+        </tr>
+        {% for row in rows %}
+        <tr>
+            <td>{{ row.task }}</td>
+            {% for cell in row.types %}
+                <td style="text-align: center{% if cell.solution_style %};{{ cell.solution_style }}{% endif %}">{{ cell.solution_points }}</td>
+                <td style="text-align: center;background-color: lavender;">{{ cell.perf }}</td>
+                <td style="text-align: center;background-color: lavender;">0</td>
+                <td style="text-align: center;">0</td>
+                <td style="text-align: center{% if cell.plagiarised %}; background-color: pink{% endif %}">{{ cell.plagiarism_points }}</td>
+            {% endfor %}
+            <td style="text-align: center;">{{ row.total }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Jinja2 to requirements
- move HTML to `templates/index.html.j2`
- refactor `scoreboard/main.py` to render via Jinja2

## Testing
- `pre-commit run --files scoreboard/CMakeLists.txt`
- `python scoreboard/main.py -o /tmp/testhtml`

------
https://chatgpt.com/codex/tasks/task_e_687c037de8fc832f816e558dfa11265d