### PR TITLE
Simplify dependency includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,16 +29,16 @@ message( STATUS "PPC step: First configures" )
 include(cmake/configure.cmake)
 include(cmake/modes.cmake)
 include(cmake/sanitizers.cmake)
-include(cmake/json.cmake)
-include(cmake/libenvpp.cmake)
-include(cmake/stb.cmake)
+foreach(dep json libenvpp stb)
+    include(cmake/${dep}.cmake)
+endforeach()
 
 ################# Parallel programming technologies #################
 
 message( STATUS "PPC step: Setup parallel programming technologies" )
-include(cmake/mpi.cmake)
-include(cmake/openmp.cmake)
-include(cmake/onetbb.cmake)
+foreach(dep mpi openmp onetbb)
+    include(cmake/${dep}.cmake)
+endforeach()
 
 ######################### External projects #########################
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -27,7 +27,16 @@ target_include_directories(
   ${exec_func_lib} PUBLIC ${CMAKE_SOURCE_DIR}/3rdparty
                           ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/tasks)
 
-foreach(link envpp json gtest threads openmp tbb mpi stb)
+foreach(
+  link
+  envpp
+  json
+  gtest
+  threads
+  openmp
+  tbb
+  mpi
+  stb)
   cmake_language(CALL "ppc_link_${link}" ${exec_func_lib})
 endforeach()
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(
                           ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/tasks)
 
 foreach(link envpp json gtest threads openmp tbb mpi stb)
-  ppc_link_${link}(${exec_func_lib})
+  cmake_language(CALL "ppc_link_${link}" ${exec_func_lib})
 endforeach()
 
 add_executable(${exec_func_tests} ${FUNC_TESTS_SOURCE_FILES})

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -27,14 +27,9 @@ target_include_directories(
   ${exec_func_lib} PUBLIC ${CMAKE_SOURCE_DIR}/3rdparty
                           ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/tasks)
 
-ppc_link_envpp(${exec_func_lib})
-ppc_link_json(${exec_func_lib})
-ppc_link_gtest(${exec_func_lib})
-ppc_link_threads(${exec_func_lib})
-ppc_link_openmp(${exec_func_lib})
-ppc_link_tbb(${exec_func_lib})
-ppc_link_mpi(${exec_func_lib})
-ppc_link_stb(${exec_func_lib})
+foreach(link envpp json gtest threads openmp tbb mpi stb)
+  ppc_link_${link}(${exec_func_lib})
+endforeach()
 
 add_executable(${exec_func_tests} ${FUNC_TESTS_SOURCE_FILES})
 


### PR DESCRIPTION
- reduce cmake boilerplate for 3rdparty includes
- compact third-party link statements for modules