### PR TITLE
[CI] Build up-to-date Docker image version on pre-commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'docker/**'
       - '.github/workflows/docker.yml'
-  pull_request_target:
+  pull_request:
     paths:
       - 'docker/**'
       - '.github/workflows/docker.yml'
@@ -33,6 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
 - pre-commit job only build the docker image to verify whether it is working well
 - post-commit stage (on master branch only) builds the final version and pushes to the registry under the `latest` version