### PR TITLE
Add USE_COVERAGE option to configure.cmake

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -28,6 +28,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
+option(USE_COVERAGE "Enable coverage instrumentation" OFF)
+
 if(USE_COVERAGE)
   set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/ppc_onetbb/install/lib")
 else()


### PR DESCRIPTION
## Summary
- allow enabling coverage in CMake via `USE_COVERAGE` option

## Testing
- `pre-commit run --files cmake/configure.cmake`

------
https://chatgpt.com/codex/tasks/task_e_688cdae278d0832f9e49371f741cb580