### PR TITLE
Introduce PPC_IMPLEMENTATIONS variable

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -83,7 +83,7 @@ function(ppc_configure_subproject SUBDIR)
   message(STATUS "${SUBDIR}")
 
   # List of implementations to configure
-  foreach(IMPL IN LISTS IMPLEMENTATIONS)
+  foreach(IMPL IN LISTS PPC_IMPLEMENTATIONS)
     setup_implementation(
       NAME
       ${IMPL}

--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -18,7 +18,7 @@ ppc_add_test(${FUNC_TEST_EXEC} common/runners/functional.cpp USE_FUNC_TESTS)
 ppc_add_test(${PERF_TEST_EXEC} common/runners/performance.cpp USE_PERF_TESTS)
 
 # ——— List of implementations ————————————————————————————————————————
-set(IMPLEMENTATIONS all mpi omp seq stl tbb)
+set(PPC_IMPLEMENTATIONS "all;mpi;omp;seq;stl;tbb" CACHE STRING "Implementations to build (semicolon-separated)")
 
 # ——— Configure each subproject —————————————————————————————————————
 file(


### PR DESCRIPTION
Introduced a cache variable `PPC_IMPLEMENTATIONS` in the student tasks CMake configuration, so implementations can be customized during CMake configuration