### PR TITLE
[CI] Execute 'update-pre-commit' routine only in the template repository

### DIFF
--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   update-pre-commit:
+    if: ${{ github.repository == 'learning-process/parallel_programming_course' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Do not perform updating pre-commit hook dependencies in repositories that were instantiated from this template repo