### PR TITLE
[CI] Remove old labels using actions/labeler@v6 automatically

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,4 +19,5 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labeler.yml"
+          sync-labels: true
           dot: true


### PR DESCRIPTION
Default behavior of actions/labeler@v6 does not remove outdated/stle labels (it only adds new) this PR enforces re-checking all labels
