### PR TITLE
[doc] Mention 'brew link libomp' in macOS setup guide

### DIFF
--- a/docs/user_guide/environment.rst
+++ b/docs/user_guide/environment.rst
@@ -125,6 +125,7 @@ Parallel Programming Technologies
 
      brew install llvm
      brew install libomp
+     brew link libomp --overwrite --force
 
 ``TBB``
 ~~~~~~~


### PR DESCRIPTION
Add missing bullet in macOS set up guide that could be helpful on some systems