### PR TITLE
Enable 'clang-analyzer-*' and 'clang-diagnostic-*' warnings in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   cert-msc51-cpp,
   cert-oop57-cpp,
   cert-oop58-cpp,
+  clang-*,
   concurrency-*,
   cppcoreguidelines-*,
   google-*,


### PR DESCRIPTION
Enable clang-analyzer and clang-diagnostic scopes in clang-tidy