### PR TITLE
[CI] Perform ARM checks on nightly basis only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
     needs:
       - pre-commit
     uses: ./.github/workflows/ubuntu.yml
+    with:
+      is_nightly: ${{ github.event_name == 'schedule' }}
   mac:
     needs:
       - pre-commit

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,12 @@ name: Ubuntu
 
 on:
   workflow_call:
+    inputs:
+      is_nightly:
+        description: 'Is nightly CI run'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -17,7 +23,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
         build_type: [Release, Debug]
     steps:
       - uses: actions/checkout@v6
@@ -71,7 +77,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Download installed package
@@ -103,7 +109,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Download installed package
@@ -127,7 +133,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -172,7 +178,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Download installed package
@@ -204,7 +210,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        os: ${{ fromJSON(inputs.is_nightly && '["ubuntu-24.04","ubuntu-24.04-arm"]' || '["ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Download installed package


### PR DESCRIPTION
To save up resources, let's switch ARM testing to the scope that is executed more rarely. According to the practical experience, there was no added value on pre-commit checks on that architecture