### PR TITLE
Add PPC_TASKS build selector

### DIFF
--- a/docs/locale/en/LC_MESSAGES/user_guide/build.po
+++ b/docs/locale/en/LC_MESSAGES/user_guide/build.po
@@ -35,48 +35,65 @@ msgid "**Configure the build**: ``Makefile``, ``.sln``, etc."
 msgstr ""
 
 #: ../../../../docs/user_guide/build.rst:12
-msgid "Optional: enable sanitizers for local debugging"
+msgid "To configure only selected tasks:"
 msgstr ""
 
 #: ../../../../docs/user_guide/build.rst:18
-msgid "*Help on CMake keys:*"
-msgstr ""
-
-#: ../../../../docs/user_guide/build.rst:21
-msgid "``-D USE_FUNC_TESTS=ON`` enable functional tests."
-msgstr ""
-
-#: ../../../../docs/user_guide/build.rst:22
-msgid "``-D USE_PERF_TESTS=ON`` enable performance tests."
-msgstr ""
-
-#: ../../../../docs/user_guide/build.rst:23
-msgid "``-D CMAKE_BUILD_TYPE=Release`` normal build (default)."
+msgid "Optional: enable sanitizers for local debugging"
 msgstr ""
 
 #: ../../../../docs/user_guide/build.rst:24
+msgid "*Help on CMake keys:*"
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:27
+msgid "``-D USE_FUNC_TESTS=ON`` enable functional tests."
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:28
+msgid "``-D USE_PERF_TESTS=ON`` enable performance tests."
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:29
+msgid ""
+"``-D PPC_TASKS=all`` builds every task (default). Pass one task or a "
+"semicolon list, for example ``-D PPC_TASKS=\"example_threads;example_processes\"``, "
+"to limit the build."
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:32
+msgid ""
+"``-D PPC_IMPLEMENTATIONS=\"seq;omp\"`` select implementation folders to "
+"configure."
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:34
+msgid "``-D CMAKE_BUILD_TYPE=Release`` normal build (default)."
+msgstr ""
+
+#: ../../../../docs/user_guide/build.rst:35
 msgid ""
 "``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers "
 "or running ``valgrind`` to keep debug information."
 msgstr ""
 
-#: ../../../../docs/user_guide/build.rst:26
+#: ../../../../docs/user_guide/build.rst:37
 msgid "``-D CMAKE_BUILD_TYPE=Debug`` for debugging sessions."
 msgstr ""
 
-#: ../../../../docs/user_guide/build.rst:28
+#: ../../../../docs/user_guide/build.rst:39
 msgid "*A corresponding flag can be omitted if it's not needed.*"
 msgstr ""
 
-#: ../../../../docs/user_guide/build.rst:30
+#: ../../../../docs/user_guide/build.rst:41
 msgid "**Build the project**:"
 msgstr ""
 
-#: ../../../../docs/user_guide/build.rst:36
+#: ../../../../docs/user_guide/build.rst:47
 msgid "**Run tests**:"
 msgstr ""
 
-#: ../../../../docs/user_guide/build.rst:38
+#: ../../../../docs/user_guide/build.rst:49
 msgid "Prefer the helper runner described in ``User Guide → CI``."
 msgstr ""
 
@@ -88,4 +105,3 @@ msgstr ""
 
 #~ msgid "Run ``<project's folder>/build/bin``"
 #~ msgstr ""
-

--- a/docs/locale/ru/LC_MESSAGES/user_guide/build.po
+++ b/docs/locale/ru/LC_MESSAGES/user_guide/build.po
@@ -35,26 +35,49 @@ msgid "**Configure the build**: ``Makefile``, ``.sln``, etc."
 msgstr "**Конфигурация проекта**: ``Makefile``, ``.sln``, и т.д."
 
 #: ../../../../docs/user_guide/build.rst:12
+msgid "To configure only selected tasks:"
+msgstr "Чтобы сконфигурировать только выбранные задачи:"
+
+#: ../../../../docs/user_guide/build.rst:18
 msgid "Optional: enable sanitizers for local debugging"
 msgstr "Дополнительно: включите санитайзеры для локальной отладки"
 
-#: ../../../../docs/user_guide/build.rst:18
+#: ../../../../docs/user_guide/build.rst:24
 msgid "*Help on CMake keys:*"
 msgstr "*Важные CMake ключи для конфигурации проекта:*"
 
-#: ../../../../docs/user_guide/build.rst:21
+#: ../../../../docs/user_guide/build.rst:27
 msgid "``-D USE_FUNC_TESTS=ON`` enable functional tests."
 msgstr "``-D USE_FUNC_TESTS=ON`` включает функциональные тесты."
 
-#: ../../../../docs/user_guide/build.rst:22
+#: ../../../../docs/user_guide/build.rst:28
 msgid "``-D USE_PERF_TESTS=ON`` enable performance tests."
 msgstr "``-D USE_PERF_TESTS=ON`` включает тесты на производительность."
 
-#: ../../../../docs/user_guide/build.rst:23
+#: ../../../../docs/user_guide/build.rst:29
+msgid ""
+"``-D PPC_TASKS=all`` builds every task (default). Pass one task or a "
+"semicolon list, for example ``-D PPC_TASKS=\"example_threads;example_processes\"``, "
+"to limit the build."
+msgstr ""
+"``-D PPC_TASKS=all`` собирает все задачи (по умолчанию). Укажите одну "
+"задачу или список через точку с запятой, например "
+"``-D PPC_TASKS=\"example_threads;example_processes\"``, чтобы ограничить "
+"сборку."
+
+#: ../../../../docs/user_guide/build.rst:32
+msgid ""
+"``-D PPC_IMPLEMENTATIONS=\"seq;omp\"`` select implementation folders to "
+"configure."
+msgstr ""
+"``-D PPC_IMPLEMENTATIONS=\"seq;omp\"`` выбирает папки реализаций для "
+"конфигурации."
+
+#: ../../../../docs/user_guide/build.rst:34
 msgid "``-D CMAKE_BUILD_TYPE=Release`` normal build (default)."
 msgstr "``-D CMAKE_BUILD_TYPE=Release`` нормальная сборка (по умолчанию)."
 
-#: ../../../../docs/user_guide/build.rst:24
+#: ../../../../docs/user_guide/build.rst:35
 msgid ""
 "``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers "
 "or running ``valgrind`` to keep debug information."
@@ -63,25 +86,25 @@ msgstr ""
 "санитайзеров или запуске ``valgrind`` для сохранения отладочной "
 "информации."
 
-#: ../../../../docs/user_guide/build.rst:26
+#: ../../../../docs/user_guide/build.rst:37
 msgid "``-D CMAKE_BUILD_TYPE=Debug`` for debugging sessions."
 msgstr "``-D CMAKE_BUILD_TYPE=Debug`` используется при отладке."
 
-#: ../../../../docs/user_guide/build.rst:28
+#: ../../../../docs/user_guide/build.rst:39
 msgid "*A corresponding flag can be omitted if it's not needed.*"
 msgstr ""
 "*Ряд CMake флагов может быть выключен, если они не требуются для "
 "выполнения работы.*"
 
-#: ../../../../docs/user_guide/build.rst:30
+#: ../../../../docs/user_guide/build.rst:41
 msgid "**Build the project**:"
 msgstr "**Построение проекта**:"
 
-#: ../../../../docs/user_guide/build.rst:36
+#: ../../../../docs/user_guide/build.rst:47
 msgid "**Run tests**:"
 msgstr "**Запуск тестов**:"
 
-#: ../../../../docs/user_guide/build.rst:38
+#: ../../../../docs/user_guide/build.rst:49
 msgid "Prefer the helper runner described in ``User Guide → CI``."
 msgstr "Рекомендуется использовать вспомогательный раннер, описанный в «Инструкция → CI»."
 

--- a/docs/user_guide/build.rst
+++ b/docs/user_guide/build.rst
@@ -9,6 +9,12 @@ Navigate to the project root.
 
       cmake -S . -B build -D USE_FUNC_TESTS=ON -D USE_PERF_TESTS=ON -D CMAKE_BUILD_TYPE=Release
 
+   To configure only selected tasks:
+
+   .. code-block:: bash
+
+      cmake -S . -B build -DPPC_TASKS="example_threads;example_processes" -D USE_FUNC_TESTS=ON -D USE_PERF_TESTS=ON -D CMAKE_BUILD_TYPE=Release
+
    Optional: enable sanitizers for local debugging
 
    .. code-block:: bash
@@ -20,6 +26,11 @@ Navigate to the project root.
 
    - ``-D USE_FUNC_TESTS=ON`` enable functional tests.
    - ``-D USE_PERF_TESTS=ON`` enable performance tests.
+   - ``-D PPC_TASKS=all`` builds every task (default). Pass one task or a semicolon list,
+     for example ``-D PPC_TASKS="example_threads;example_processes"``, to limit
+     the build.
+   - ``-D PPC_IMPLEMENTATIONS="seq;omp"`` select implementation folders to
+     configure.
    - ``-D CMAKE_BUILD_TYPE=Release`` normal build (default).
    - ``-D CMAKE_BUILD_TYPE=RelWithDebInfo`` recommended when using sanitizers or
      running ``valgrind`` to keep debug information.

--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -16,14 +16,31 @@ ppc_add_test(${PERF_TEST_EXEC} common/runners/performance.cpp USE_PERF_TESTS)
 # ——— List of implementations ————————————————————————————————————————
 set(PPC_IMPLEMENTATIONS "all;mpi;omp;seq;stl;tbb" CACHE STRING "Implementations to build (semicolon-separated)")
 
+# ——— List of tasks ———————————————————————————————————————————————————
+set(PPC_TASKS "all" CACHE STRING "Tasks to build (semicolon-separated, or 'all')")
+
 # ——— Configure each subproject —————————————————————————————————————
 file(
   GLOB subdirs
   RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
   "${CMAKE_CURRENT_SOURCE_DIR}/*")
+set(available_tasks "")
 foreach(sub IN LISTS subdirs)
-  if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sub}" AND NOT sub STREQUAL
-                                                           "common")
-    ppc_configure_subproject(${sub})
+  if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sub}" AND NOT sub STREQUAL "common")
+    list(APPEND available_tasks "${sub}")
   endif()
+endforeach()
+list(SORT available_tasks)
+
+set(selected_tasks ${PPC_TASKS})
+if(PPC_TASKS STREQUAL "all")
+  set(selected_tasks ${available_tasks})
+endif()
+
+foreach(sub IN LISTS selected_tasks)
+  if(NOT sub IN_LIST available_tasks)
+    string(JOIN ", " available_tasks_message ${available_tasks})
+    message(FATAL_ERROR "Unknown PPC_TASKS entry '${sub}'. Available tasks: ${available_tasks_message}")
+  endif()
+  ppc_configure_subproject(${sub})
 endforeach()


### PR DESCRIPTION
Add `PPC_TASKS` for developers to make local builds much more lightweight by building only selected tasks