### PR TITLE
Stabilize MPI test timing

### DIFF
--- a/modules/runners/src/runners.cpp
+++ b/modules/runners/src/runners.cpp
@@ -82,22 +82,22 @@ int RunAllTests() {
 }
 
 void SyncGTestSeed() {
-  unsigned int seed = 0;
   int rank = -1;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  if (rank == 0) {
+  int seed = ::testing::GTEST_FLAG(random_seed);
+  if (rank == 0 && seed == 0) {
     try {
-      seed = std::random_device{}();
+      seed = static_cast<int>((std::random_device{}() % 99999U) + 1U);
     } catch (...) {
       seed = 0;
     }
     if (seed == 0) {
       const auto now = static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
-      seed = static_cast<unsigned int>(((now & 0x7fffffffULL) | 1ULL));
+      seed = static_cast<int>((now % 99999ULL) + 1ULL);
     }
   }
-  MPI_Bcast(&seed, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
-  ::testing::GTEST_FLAG(random_seed) = static_cast<int>(seed);
+  MPI_Bcast(&seed, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  ::testing::GTEST_FLAG(random_seed) = seed;
 }
 
 void SyncGTestFilter() {

--- a/modules/util/include/func_test_util.hpp
+++ b/modules/util/include/func_test_util.hpp
@@ -103,6 +103,7 @@ class BaseRunFuncTests : public ::testing::TestWithParam<FuncTestParam<InType, O
 
   void ValidateTask() {
     EXPECT_TRUE(task_->Validation());
+    SynchronizeMpiRanks();
     EXPECT_TRUE(task_->PreProcessing());
   }
 

--- a/modules/util/include/perf_test_util.hpp
+++ b/modules/util/include/perf_test_util.hpp
@@ -85,6 +85,7 @@ class BaseRunPerfTests : public ::testing::TestWithParam<PerfTestParam<InType, O
     task_ = task_getter(GetTestInputData());
     ppc::performance::Perf perf(task_);
     ppc::performance::PerfAttr perf_attr;
+    SynchronizeMpiRanks();
     SetPerfAttributes(perf_attr);
 
     if (mode == ppc::performance::PerfResults::TypeOfRunning::kPipeline) {

--- a/modules/util/include/util.hpp
+++ b/modules/util/include/util.hpp
@@ -75,6 +75,7 @@ int GetNumThreads();
 int GetNumProc();
 double GetTaskMaxTime();
 double GetPerfMaxTime();
+void SynchronizeMpiRanks();
 
 template <typename T>
 std::string GetNamespace() {

--- a/modules/util/src/util.cpp
+++ b/modules/util/src/util.cpp
@@ -1,5 +1,7 @@
 #include "util/include/util.hpp"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <array>
 #include <filesystem>
@@ -64,4 +66,21 @@ bool ppc::util::IsUnderMpirun() {
     const auto mpi_env = env::get<int>(env_var);
     return static_cast<bool>(mpi_env.has_value());
   });
+}
+
+void ppc::util::SynchronizeMpiRanks() {
+  int initialized = 0;
+  if (MPI_Initialized(&initialized) != MPI_SUCCESS || initialized == 0) {
+    return;
+  }
+
+  int finalized = 0;
+  if (MPI_Finalized(&finalized) != MPI_SUCCESS || finalized != 0) {
+    return;
+  }
+
+  const int barrier_res = MPI_Barrier(MPI_COMM_WORLD);
+  if (barrier_res != MPI_SUCCESS) {
+    MPI_Abort(MPI_COMM_WORLD, barrier_res);
+  }
 }


### PR DESCRIPTION
Synchronize ranks before timed sections so scheduler skew and barrier waits are not counted as task runtime, preventing rare timeout flakes like these:

```
[ RUN      ] PicMatrixTests/NesterovARunFuncTestsProcesses3.MatmulFromPic/nesterov_a_test_task_processes_3_mpi_enabled_3_3
unknown file: error: C++ exception with description "
Task execute time need to be: time < 1 secs.
Original time in secs: 1.21769
" thrown in the test body.

[       OK ] PicMatrixTests/NesterovARunFuncTestsProcesses3.MatmulFromPic/nesterov_a_test_task_processes_3_mpi_enabled_3_3 (1224 ms)
[  FAILED  ] PicMatrixTests/NesterovARunFuncTestsProcesses3.MatmulFromPic/nesterov_a_test_task_processes_3_mpi_enabled_3_3, where GetParam() = (64-byte object <20-AA 75-60 F6-7F 00-00 C0-6C 6E-60 F6-7F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 88-77 B8-48 FD-01 00-00>, "nesterov_a_test_task_processes_3_mpi_enabled", (3, "3")) (1225 ms)
[ RUN      ] PicMatrixTests/NesterovARunFuncTestsProcesses3.MatmulFromPic/nesterov_a_test_task_processes_3_mpi_enabled_7_7

job aborted:
[ranks] message

[0] terminated

[1] application aborted
aborting MPI_COMM_WORLD (comm=0x44000000), error 1, comm rank 1

[2] terminated

---- error analysis -----

[1] on runnervmqq1k9
D:\a\parallel_programming_course\parallel_programming_course\install\bin\ppc_func_tests aborted the job. abort code 1

---- error analysis -----
 [  PROCESS 1  ]  [  PROCESS 1  ] Traceback (most recent call last):
  File "D:\a\parallel_programming_course\parallel_programming_course\scripts\run_tests.py", line 308, in <module>
    _execute(args_dict, env_copy)
  File "D:\a\parallel_programming_course\parallel_programming_course\scripts\run_tests.py", line 283, in _execute
    runner.run_processes(args_dict["additional_mpi_args"])
  File "D:\a\parallel_programming_course\parallel_programming_course\scripts\run_tests.py", line 247, in run_processes
    self.__run_exec(
  File "D:\a\parallel_programming_course\parallel_programming_course\scripts\run_tests.py", line 122, in __run_exec
    raise Exception(f"Subprocess return {result.returncode}.")
Exception: Subprocess return 1.
Error: Process completed with exit code 1.
```

Please go to the `Preview` tab and select the appropriate template:

* [Submit Student task (English)](?expand=1&template=task_submission_en.md)
* [Submit Student task (Russian)](?expand=1&template=task_submission_ru.md)
* [Submit Fix for Student task (English)](?expand=1&template=task_fix_submission_en.md)
* [Submit Fix for Student task (Russian)](?expand=1&template=task_fix_submission_ru.md)
