### PR TITLE
Clean up clang-tidy suppressions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,6 +46,7 @@ Checks: >
   -readability-magic-numbers
 
 HeaderFilterRegex: '.*/(modules|tasks)/.*'
+ExcludeHeaderFilterRegex: '.*/3rdparty/.*'
 
 CheckOptions:
   - key: readability-identifier-naming.ClassCase

--- a/modules/performance/tests/.clang-tidy
+++ b/modules/performance/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 50  # Relaxed for tests

--- a/modules/performance/tests/perf_tests.cpp
+++ b/modules/performance/tests/perf_tests.cpp
@@ -1,13 +1,14 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <libenvpp/detail/environment.hpp>
 #include <memory>
-#include <ostream>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <vector>
@@ -29,6 +30,7 @@ class TestPerfTask : public ppc::task::Task<InType, OutType> {
     this->GetInput() = in;
   }
 
+ protected:
   bool ValidationImpl() override {
     return !this->GetInput().empty();
   }
@@ -55,6 +57,7 @@ class FakePerfTask : public TestPerfTask<InType, OutType> {
  public:
   explicit FakePerfTask(const InType &in) : TestPerfTask<InType, OutType>(in) {}
 
+ protected:
   bool RunImpl() override {
     std::this_thread::sleep_for(std::chrono::seconds(11));
     return TestPerfTask<InType, OutType>::RunImpl();
@@ -163,38 +166,31 @@ TEST(PerfTests, CheckPerfTaskFloat) {
 
 struct ParamTestCase {
   PerfResults::TypeOfRunning input;
-  std::string expected_output;
-  friend void PrintTo(const ParamTestCase &param, std::ostream *os) {
-    *os << "{ input = " << static_cast<int>(param.input) << ", expected = " << param.expected_output << " }";
-  }
+  std::string_view expected_output;
 };
 
-class GetStringParamNameParamTest : public ::testing::TestWithParam<ParamTestCase> {};
+namespace {
 
-TEST_P(GetStringParamNameParamTest, ReturnsExpectedString) {
-  const auto &param = GetParam();
-  EXPECT_EQ(GetStringParamName(param.input), param.expected_output);
+constexpr std::array<ParamTestCase, 3> kParamTestCases = {
+    {{.input = PerfResults::TypeOfRunning::kTaskRun, .expected_output = "task_run"},
+     {.input = PerfResults::TypeOfRunning::kPipeline, .expected_output = "pipeline"},
+     {.input = PerfResults::TypeOfRunning::kNone, .expected_output = "none"}}};
+
+}  // namespace
+
+TEST(GetStringParamNameParamTest, ReturnsExpectedString) {
+  for (const auto &param : kParamTestCases) {
+    EXPECT_EQ(GetStringParamName(param.input), std::string(param.expected_output));
+  }
 }
-
-INSTANTIATE_TEST_SUITE_P(ParamTests, GetStringParamNameParamTest,
-                         ::testing::Values(ParamTestCase{PerfResults::TypeOfRunning::kTaskRun, "task_run"},
-                                           ParamTestCase{PerfResults::TypeOfRunning::kPipeline, "pipeline"},
-                                           ParamTestCase{PerfResults::TypeOfRunning::kNone, "none"}),
-                         [](const ::testing::TestParamInfo<ParamTestCase> &info) {
-                           return info.param.expected_output;
-                         });
 
 struct TaskTypeTestCase {
   TypeOfTask type;
-  std::string expected;
-  std::string label;
-  friend void PrintTo(const TaskTypeTestCase &param, std::ostream *os) {
-    *os << "{ type = " << static_cast<int>(param.type) << ", expected = " << param.expected
-        << ", label = " << param.label << " }";
-  }
+  std::string_view expected;
+  std::string_view label;
 };
 
-class GetStringTaskTypeTest : public ::testing::TestWithParam<TaskTypeTestCase> {
+class GetStringTaskTypeTest : public ::testing::Test {
  protected:
   std::string temp_path;
 
@@ -211,18 +207,23 @@ class GetStringTaskTypeTest : public ::testing::TestWithParam<TaskTypeTestCase> 
   }
 };
 
-TEST_P(GetStringTaskTypeTest, ReturnsExpectedString) {
-  const auto &param = GetParam();
-  EXPECT_EQ(GetStringTaskType(param.type, temp_path), param.expected) << "Failed on: " << param.label;
-}
+namespace {
 
-INSTANTIATE_TEST_SUITE_P(AllTypeCases, GetStringTaskTypeTest,
-                         ::testing::Values(TaskTypeTestCase{TypeOfTask::kALL, "all_ALL", "kALL"},
-                                           TaskTypeTestCase{TypeOfTask::kSTL, "stl_STL", "kSTL"},
-                                           TaskTypeTestCase{TypeOfTask::kOMP, "omp_OMP", "kOMP"},
-                                           TaskTypeTestCase{TypeOfTask::kMPI, "mpi_MPI", "kMPI"},
-                                           TaskTypeTestCase{TypeOfTask::kTBB, "tbb_TBB", "kTBB"},
-                                           TaskTypeTestCase{TypeOfTask::kSEQ, "seq_SEQ", "kSEQ"}));
+constexpr std::array<TaskTypeTestCase, 6> kTaskTypeTestCases = {
+    {{.type = TypeOfTask::kALL, .expected = "all_ALL", .label = "kALL"},
+     {.type = TypeOfTask::kSTL, .expected = "stl_STL", .label = "kSTL"},
+     {.type = TypeOfTask::kOMP, .expected = "omp_OMP", .label = "kOMP"},
+     {.type = TypeOfTask::kMPI, .expected = "mpi_MPI", .label = "kMPI"},
+     {.type = TypeOfTask::kTBB, .expected = "tbb_TBB", .label = "kTBB"},
+     {.type = TypeOfTask::kSEQ, .expected = "seq_SEQ", .label = "kSEQ"}}};
+
+}  // namespace
+
+TEST_F(GetStringTaskTypeTest, ReturnsExpectedString) {
+  for (const auto &param : kTaskTypeTestCases) {
+    EXPECT_EQ(GetStringTaskType(param.type, temp_path), std::string(param.expected)) << "Failed on: " << param.label;
+  }
+}
 
 TEST(GetStringTaskTypeStandaloneTest, ThrowsIfFileMissing) {
   std::string missing_path = "non_existent_settings.json";
@@ -284,6 +285,8 @@ TEST(GetStringTaskStatusTest, HandlesEnabledAndDisabled) {
 class DummyTask : public Task<int, int> {
  public:
   using Task::Task;
+
+ protected:
   bool ValidationImpl() override {
     return true;
   }
@@ -321,25 +324,16 @@ struct Type {};
 class Another {};
 }  // namespace my
 
-template <typename T>
-class GetNamespaceTest : public ::testing::Test {};
+TEST(GetNamespaceTest, ExtractsNestedNamespaceCorrectly) {
+  EXPECT_EQ(ppc::util::GetNamespace<my::nested::Type>(), "ppc::performance::my::nested");
+}
 
-using TestTypes = ::testing::Types<my::nested::Type, my::Another, int>;
+TEST(GetNamespaceTest, ExtractsParentNamespaceCorrectly) {
+  EXPECT_EQ(ppc::util::GetNamespace<my::Another>(), "ppc::performance::my");
+}
 
-TYPED_TEST_SUITE(GetNamespaceTest, TestTypes);
-
-TYPED_TEST(GetNamespaceTest, ExtractsNamespaceCorrectly) {
-  std::string k_ns = ppc::util::GetNamespace<TypeParam>();
-
-  if constexpr (std::is_same_v<TypeParam, my::nested::Type>) {
-    EXPECT_EQ(k_ns, "ppc::performance::my::nested");
-  } else if constexpr (std::is_same_v<TypeParam, my::Another>) {
-    EXPECT_EQ(k_ns, "ppc::performance::my");
-  } else if constexpr (std::is_same_v<TypeParam, int>) {
-    EXPECT_EQ(k_ns, "");
-  } else {
-    FAIL() << "Unhandled type in test";
-  }
+TEST(GetNamespaceTest, ReturnsEmptyStringForGlobalNamespaceType) {
+  EXPECT_EQ(ppc::util::GetNamespace<int>(), "");
 }
 
 TEST(PerfTest, PipelineRunAndTaskRun) {
@@ -385,6 +379,7 @@ TEST(PerfTest, GetStringParamNameTest) {
 TEST(TaskTest, DestructorInvalidPipelineOrderTerminatesPartialPipeline) {
   {
     struct BadTask : Task<int, int> {
+     protected:
       bool ValidationImpl() override {
         return true;
       }

--- a/modules/task/tests/.clang-tidy
+++ b/modules/task/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 100  # Relaxed for tests

--- a/tasks/example_processes/tests/.clang-tidy
+++ b/tasks/example_processes/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 50  # Relaxed for tests

--- a/tasks/example_processes/tests/functional/main.cpp
+++ b/tasks/example_processes/tests/functional/main.cpp
@@ -27,7 +27,18 @@ class NesterovARunFuncTestsProcesses : public ppc::util::BaseRunFuncTests<InType
   }
 
  protected:
-  void SetUp() override {
+  void RunTestCase(const ppc::util::FuncTestParam<InType, OutType, TestType> &test_param) {
+    const std::string &test_name =
+        std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kNameTest)>(test_param);
+    if (IsTestDisabled(test_name) || ShouldSkipNonMpiTask(test_name)) {
+      return;
+    }
+
+    SetInputData();
+    ExecuteTest(test_param);
+  }
+
+  void SetInputData() {
     int width = -1;
     int height = -1;
     int channels = -1;
@@ -47,7 +58,6 @@ class NesterovARunFuncTestsProcesses : public ppc::util::BaseRunFuncTests<InType
       }
     }
 
-    TestType params = std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kTestParams)>(GetParam());
     input_data_ = width - height + std::min(std::accumulate(img.begin(), img.end(), 0), channels);
   }
 
@@ -65,22 +75,16 @@ class NesterovARunFuncTestsProcesses : public ppc::util::BaseRunFuncTests<InType
 
 namespace {
 
-TEST_P(NesterovARunFuncTestsProcesses, MatmulFromPic) {
-  ExecuteTest(GetParam());
-}
-
 const std::array<TestType, 3> kTestParam = {std::make_tuple(3, "3"), std::make_tuple(5, "5"), std::make_tuple(7, "7")};
 
 const auto kTestTasksList =
     std::tuple_cat(ppc::util::AddFuncTask<NesterovATestTaskMPI, InType>(kTestParam, PPC_SETTINGS_example_processes),
                    ppc::util::AddFuncTask<NesterovATestTaskSEQ, InType>(kTestParam, PPC_SETTINGS_example_processes));
 
-const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
-
-const auto kPerfTestName = NesterovARunFuncTestsProcesses::PrintFuncTestName<NesterovARunFuncTestsProcesses>;
-
-INSTANTIATE_TEST_SUITE_P(PicMatrixTests, NesterovARunFuncTestsProcesses, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(NesterovARunFuncTestsProcesses, MatmulFromPic) {
+  std::apply([this](const auto &...test_params) { (RunTestCase(test_params), ...); }, kTestTasksList);
+}
 
 }  // namespace nesterov_a_test_task_processes

--- a/tasks/example_processes/tests/performance/main.cpp
+++ b/tasks/example_processes/tests/performance/main.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include "example_processes/common/include/common.hpp"
 #include "example_processes/mpi/include/ops_mpi.hpp"
 #include "example_processes/seq/include/ops_seq.hpp"
@@ -8,9 +10,7 @@
 namespace nesterov_a_test_task_processes {
 
 class ExampleRunPerfTestProcesses : public ppc::util::BaseRunPerfTests<InType, OutType> {
-  const int kCount_ = 100;
-  InType input_data_{};
-
+ protected:
   void SetUp() override {
     input_data_ = kCount_;
   }
@@ -22,23 +22,21 @@ class ExampleRunPerfTestProcesses : public ppc::util::BaseRunPerfTests<InType, O
   InType GetTestInputData() final {
     return input_data_;
   }
-};
 
-TEST_P(ExampleRunPerfTestProcesses, RunPerfModes) {
-  ExecuteTest(GetParam());
-}
+ private:
+  const int kCount_ = 100;
+  InType input_data_{};
+};
 
 namespace {
 
 const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, NesterovATestTaskMPI, NesterovATestTaskSEQ>(PPC_SETTINGS_example_processes);
 
-const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
-
-const auto kPerfTestName = ExampleRunPerfTestProcesses::CustomPerfTestName;
-
-INSTANTIATE_TEST_SUITE_P(RunModeTests, ExampleRunPerfTestProcesses, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(ExampleRunPerfTestProcesses, RunPerfModes) {
+  std::apply([this](const auto &...test_params) { (ExecuteTest(test_params), ...); }, kAllPerfTasks);
+}
 
 }  // namespace nesterov_a_test_task_processes

--- a/tasks/example_processes_2/tests/.clang-tidy
+++ b/tasks/example_processes_2/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 50  # Relaxed for tests

--- a/tasks/example_processes_2/tests/functional/main.cpp
+++ b/tasks/example_processes_2/tests/functional/main.cpp
@@ -27,7 +27,18 @@ class NesterovARunFuncTestsProcesses2 : public ppc::util::BaseRunFuncTests<InTyp
   }
 
  protected:
-  void SetUp() override {
+  void RunTestCase(const ppc::util::FuncTestParam<InType, OutType, TestType> &test_param) {
+    const std::string &test_name =
+        std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kNameTest)>(test_param);
+    if (IsTestDisabled(test_name) || ShouldSkipNonMpiTask(test_name)) {
+      return;
+    }
+
+    SetInputData();
+    ExecuteTest(test_param);
+  }
+
+  void SetInputData() {
     int width = -1;
     int height = -1;
     int channels = -1;
@@ -47,7 +58,6 @@ class NesterovARunFuncTestsProcesses2 : public ppc::util::BaseRunFuncTests<InTyp
       }
     }
 
-    TestType params = std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kTestParams)>(GetParam());
     input_data_ = width - height + std::min(std::accumulate(img.begin(), img.end(), 0), channels);
   }
 
@@ -65,22 +75,16 @@ class NesterovARunFuncTestsProcesses2 : public ppc::util::BaseRunFuncTests<InTyp
 
 namespace {
 
-TEST_P(NesterovARunFuncTestsProcesses2, MatmulFromPic) {
-  ExecuteTest(GetParam());
-}
-
 const std::array<TestType, 3> kTestParam = {std::make_tuple(3, "3"), std::make_tuple(5, "5"), std::make_tuple(7, "7")};
 
 const auto kTestTasksList =
     std::tuple_cat(ppc::util::AddFuncTask<NesterovATestTaskMPI, InType>(kTestParam, PPC_SETTINGS_example_processes_2),
                    ppc::util::AddFuncTask<NesterovATestTaskSEQ, InType>(kTestParam, PPC_SETTINGS_example_processes_2));
 
-const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
-
-const auto kPerfTestName = NesterovARunFuncTestsProcesses2::PrintFuncTestName<NesterovARunFuncTestsProcesses2>;
-
-INSTANTIATE_TEST_SUITE_P(PicMatrixTests, NesterovARunFuncTestsProcesses2, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(NesterovARunFuncTestsProcesses2, MatmulFromPic) {
+  std::apply([this](const auto &...test_params) { (RunTestCase(test_params), ...); }, kTestTasksList);
+}
 
 }  // namespace nesterov_a_test_task_processes_2

--- a/tasks/example_processes_2/tests/performance/main.cpp
+++ b/tasks/example_processes_2/tests/performance/main.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include "example_processes_2/common/include/common.hpp"
 #include "example_processes_2/mpi/include/ops_mpi.hpp"
 #include "example_processes_2/seq/include/ops_seq.hpp"
@@ -8,9 +10,7 @@
 namespace nesterov_a_test_task_processes_2 {
 
 class ExampleRunPerfTestProcesses2 : public ppc::util::BaseRunPerfTests<InType, OutType> {
-  const int kCount_ = 100;
-  InType input_data_{};
-
+ protected:
   void SetUp() override {
     input_data_ = kCount_;
   }
@@ -22,23 +22,21 @@ class ExampleRunPerfTestProcesses2 : public ppc::util::BaseRunPerfTests<InType, 
   InType GetTestInputData() final {
     return input_data_;
   }
-};
 
-TEST_P(ExampleRunPerfTestProcesses2, RunPerfModes) {
-  ExecuteTest(GetParam());
-}
+ private:
+  const int kCount_ = 100;
+  InType input_data_{};
+};
 
 namespace {
 
 const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, NesterovATestTaskMPI, NesterovATestTaskSEQ>(PPC_SETTINGS_example_processes_2);
 
-const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
-
-const auto kPerfTestName = ExampleRunPerfTestProcesses2::CustomPerfTestName;
-
-INSTANTIATE_TEST_SUITE_P(RunModeTests, ExampleRunPerfTestProcesses2, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(ExampleRunPerfTestProcesses2, RunPerfModes) {
+  std::apply([this](const auto &...test_params) { (ExecuteTest(test_params), ...); }, kAllPerfTasks);
+}
 
 }  // namespace nesterov_a_test_task_processes_2

--- a/tasks/example_processes_3/tests/.clang-tidy
+++ b/tasks/example_processes_3/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 50  # Relaxed for tests

--- a/tasks/example_processes_3/tests/functional/main.cpp
+++ b/tasks/example_processes_3/tests/functional/main.cpp
@@ -27,7 +27,18 @@ class NesterovARunFuncTestsProcesses3 : public ppc::util::BaseRunFuncTests<InTyp
   }
 
  protected:
-  void SetUp() override {
+  void RunTestCase(const ppc::util::FuncTestParam<InType, OutType, TestType> &test_param) {
+    const std::string &test_name =
+        std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kNameTest)>(test_param);
+    if (IsTestDisabled(test_name) || ShouldSkipNonMpiTask(test_name)) {
+      return;
+    }
+
+    SetInputData();
+    ExecuteTest(test_param);
+  }
+
+  void SetInputData() {
     int width = -1;
     int height = -1;
     int channels = -1;
@@ -47,7 +58,6 @@ class NesterovARunFuncTestsProcesses3 : public ppc::util::BaseRunFuncTests<InTyp
       }
     }
 
-    TestType params = std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kTestParams)>(GetParam());
     input_data_ = width - height + std::min(std::accumulate(img.begin(), img.end(), 0), channels);
   }
 
@@ -65,22 +75,16 @@ class NesterovARunFuncTestsProcesses3 : public ppc::util::BaseRunFuncTests<InTyp
 
 namespace {
 
-TEST_P(NesterovARunFuncTestsProcesses3, MatmulFromPic) {
-  ExecuteTest(GetParam());
-}
-
 const std::array<TestType, 3> kTestParam = {std::make_tuple(3, "3"), std::make_tuple(5, "5"), std::make_tuple(7, "7")};
 
 const auto kTestTasksList =
     std::tuple_cat(ppc::util::AddFuncTask<NesterovATestTaskMPI, InType>(kTestParam, PPC_SETTINGS_example_processes_3),
                    ppc::util::AddFuncTask<NesterovATestTaskSEQ, InType>(kTestParam, PPC_SETTINGS_example_processes_3));
 
-const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
-
-const auto kPerfTestName = NesterovARunFuncTestsProcesses3::PrintFuncTestName<NesterovARunFuncTestsProcesses3>;
-
-INSTANTIATE_TEST_SUITE_P(PicMatrixTests, NesterovARunFuncTestsProcesses3, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(NesterovARunFuncTestsProcesses3, MatmulFromPic) {
+  std::apply([this](const auto &...test_params) { (RunTestCase(test_params), ...); }, kTestTasksList);
+}
 
 }  // namespace nesterov_a_test_task_processes_3

--- a/tasks/example_processes_3/tests/performance/main.cpp
+++ b/tasks/example_processes_3/tests/performance/main.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include "example_processes_3/common/include/common.hpp"
 #include "example_processes_3/mpi/include/ops_mpi.hpp"
 #include "example_processes_3/seq/include/ops_seq.hpp"
@@ -8,9 +10,7 @@
 namespace nesterov_a_test_task_processes_3 {
 
 class ExampleRunPerfTestProcesses3 : public ppc::util::BaseRunPerfTests<InType, OutType> {
-  const int kCount_ = 100;
-  InType input_data_{};
-
+ protected:
   void SetUp() override {
     input_data_ = kCount_;
   }
@@ -22,23 +22,17 @@ class ExampleRunPerfTestProcesses3 : public ppc::util::BaseRunPerfTests<InType, 
   InType GetTestInputData() final {
     return input_data_;
   }
+
+ private:
+  const int kCount_ = 100;
+  InType input_data_{};
 };
-
-TEST_P(ExampleRunPerfTestProcesses3, RunPerfModes) {
-  ExecuteTest(GetParam());
-}
-
-namespace {
 
 const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, NesterovATestTaskMPI, NesterovATestTaskSEQ>(PPC_SETTINGS_example_processes_3);
 
-const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
-
-const auto kPerfTestName = ExampleRunPerfTestProcesses3::CustomPerfTestName;
-
-INSTANTIATE_TEST_SUITE_P(RunModeTests, ExampleRunPerfTestProcesses3, kGtestValues, kPerfTestName);
-
-}  // namespace
+TEST_F(ExampleRunPerfTestProcesses3, RunPerfModes) {
+  std::apply([this](const auto &...test_params) { (ExecuteTest(test_params), ...); }, kAllPerfTasks);
+}
 
 }  // namespace nesterov_a_test_task_processes_3

--- a/tasks/example_threads/tests/.clang-tidy
+++ b/tasks/example_threads/tests/.clang-tidy
@@ -1,14 +1,5 @@
 InheritParentConfig: true
 
-Checks: >
-  -modernize-loop-convert,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-override-with-different-visibility,
-  -misc-use-anonymous-namespace,
-  -modernize-use-std-print,
-  -modernize-type-traits
-
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
     value: 50  # Relaxed for tests

--- a/tasks/example_threads/tests/functional/main.cpp
+++ b/tasks/example_threads/tests/functional/main.cpp
@@ -30,7 +30,18 @@ class NesterovARunFuncTestsThreads : public ppc::util::BaseRunFuncTests<InType, 
   }
 
  protected:
-  void SetUp() override {
+  void RunTestCase(const ppc::util::FuncTestParam<InType, OutType, TestType> &test_param) {
+    const std::string &test_name =
+        std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kNameTest)>(test_param);
+    if (IsTestDisabled(test_name) || ShouldSkipNonMpiTask(test_name)) {
+      return;
+    }
+
+    SetInputData();
+    ExecuteTest(test_param);
+  }
+
+  void SetInputData() {
     int width = -1;
     int height = -1;
     int channels = -1;
@@ -50,7 +61,6 @@ class NesterovARunFuncTestsThreads : public ppc::util::BaseRunFuncTests<InType, 
       }
     }
 
-    TestType params = std::get<static_cast<std::size_t>(ppc::util::GTestParamIndex::kTestParams)>(GetParam());
     input_data_ = width - height + std::min(std::accumulate(img.begin(), img.end(), 0), channels);
   }
 
@@ -68,10 +78,6 @@ class NesterovARunFuncTestsThreads : public ppc::util::BaseRunFuncTests<InType, 
 
 namespace {
 
-TEST_P(NesterovARunFuncTestsThreads, MatmulFromPic) {
-  ExecuteTest(GetParam());
-}
-
 const std::array<TestType, 3> kTestParam = {std::make_tuple(3, "3"), std::make_tuple(5, "5"), std::make_tuple(7, "7")};
 
 const auto kTestTasksList =
@@ -81,12 +87,10 @@ const auto kTestTasksList =
                    ppc::util::AddFuncTask<NesterovATestTaskSTL, InType>(kTestParam, PPC_SETTINGS_example_threads),
                    ppc::util::AddFuncTask<NesterovATestTaskTBB, InType>(kTestParam, PPC_SETTINGS_example_threads));
 
-const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
-
-const auto kPerfTestName = NesterovARunFuncTestsThreads::PrintFuncTestName<NesterovARunFuncTestsThreads>;
-
-INSTANTIATE_TEST_SUITE_P(PicMatrixTests, NesterovARunFuncTestsThreads, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(NesterovARunFuncTestsThreads, MatmulFromPic) {
+  std::apply([this](const auto &...test_params) { (RunTestCase(test_params), ...); }, kTestTasksList);
+}
 
 }  // namespace nesterov_a_test_task_threads

--- a/tasks/example_threads/tests/performance/main.cpp
+++ b/tasks/example_threads/tests/performance/main.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include "example_threads/all/include/ops_all.hpp"
 #include "example_threads/common/include/common.hpp"
 #include "example_threads/omp/include/ops_omp.hpp"
@@ -11,9 +13,7 @@
 namespace nesterov_a_test_task_threads {
 
 class ExampleRunPerfTestThreads : public ppc::util::BaseRunPerfTests<InType, OutType> {
-  const int kCount_ = 200;
-  InType input_data_{};
-
+ protected:
   void SetUp() override {
     input_data_ = kCount_;
   }
@@ -25,11 +25,11 @@ class ExampleRunPerfTestThreads : public ppc::util::BaseRunPerfTests<InType, Out
   InType GetTestInputData() final {
     return input_data_;
   }
-};
 
-TEST_P(ExampleRunPerfTestThreads, RunPerfModes) {
-  ExecuteTest(GetParam());
-}
+ private:
+  const int kCount_ = 200;
+  InType input_data_{};
+};
 
 namespace {
 
@@ -37,12 +37,10 @@ const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, NesterovATestTaskALL, NesterovATestTaskOMP, NesterovATestTaskSEQ,
                                 NesterovATestTaskSTL, NesterovATestTaskTBB>(PPC_SETTINGS_example_threads);
 
-const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
-
-const auto kPerfTestName = ExampleRunPerfTestThreads::CustomPerfTestName;
-
-INSTANTIATE_TEST_SUITE_P(RunModeTests, ExampleRunPerfTestThreads, kGtestValues, kPerfTestName);
-
 }  // namespace
+
+TEST_F(ExampleRunPerfTestThreads, RunPerfModes) {
+  std::apply([this](const auto &...test_params) { (ExecuteTest(test_params), ...); }, kAllPerfTasks);
+}
 
 }  // namespace nesterov_a_test_task_threads


### PR DESCRIPTION
Get rid of many tests (especially, googletest) related diagnostics suppressions, address all newly appeared clang-tidy remarks