### PR TITLE
Configure Open MPI shmem defaults on macOS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,23 @@ UseTab: Never
 AllowShortFunctionsOnASingleLine: Empty
 IndentPPDirectives: AfterHash
 SortIncludes: true
+IncludeCategories:
+  - Regex: '^<gtest/.*\.h>'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^<.*\.h>'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^<.*'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '.*'
+    Priority: 4
+    SortPriority: 0
+    CaseSensitive: false
 FixNamespaceComments: true
 InsertBraces: true
 QualifierAlignment: Left

--- a/modules/runners/src/runners.cpp
+++ b/modules/runners/src/runners.cpp
@@ -1,6 +1,7 @@
 #include "runners/include/runners.hpp"
 
 #include <gtest/gtest.h>
+
 #include <mpi.h>
 
 #include <chrono>

--- a/modules/runners/src/runners.cpp
+++ b/modules/runners/src/runners.cpp
@@ -1,7 +1,6 @@
 #include "runners/include/runners.hpp"
 
 #include <gtest/gtest.h>
-#include <mpi.h>
 
 #include <chrono>
 #include <cstdint>
@@ -10,6 +9,7 @@
 #include <format>
 #include <iostream>
 #include <memory>
+#include <mpi.h>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -140,6 +140,7 @@ int RunAllTestsSafely() {
 }  // namespace
 
 int Init(int argc, char **argv) {
+  ppc::util::ConfigureMpiEnvironment();
   const int init_res = MPI_Init(&argc, &argv);
   if (init_res != MPI_SUCCESS) {
     std::cerr << std::format("[  ERROR  ] MPI_Init failed with code {}", init_res) << '\n';

--- a/modules/runners/src/runners.cpp
+++ b/modules/runners/src/runners.cpp
@@ -1,6 +1,7 @@
 #include "runners/include/runners.hpp"
 
 #include <gtest/gtest.h>
+#include <mpi.h>
 
 #include <chrono>
 #include <cstdint>
@@ -9,7 +10,6 @@
 #include <format>
 #include <iostream>
 #include <memory>
-#include <mpi.h>
 #include <random>
 #include <stdexcept>
 #include <string>

--- a/modules/util/include/func_test_util.hpp
+++ b/modules/util/include/func_test_util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
+
 #include <tbb/tick_count.h>
 
 #include <concepts>

--- a/modules/util/include/perf_test_util.hpp
+++ b/modules/util/include/perf_test_util.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <benchmark/benchmark.h>
 #include <gtest/gtest.h>
+
+#include <benchmark/benchmark.h>
 #include <mpi.h>
 #include <omp.h>
 #include <tbb/tick_count.h>

--- a/modules/util/include/util.hpp
+++ b/modules/util/include/util.hpp
@@ -95,6 +95,7 @@ double GetTaskMaxTime();
 double GetPerfMaxTime();
 double GetTimeMPI();
 int GetMPIRank();
+void ConfigureMpiEnvironment();
 void SynchronizeMpiRanks();
 
 template <typename T>

--- a/modules/util/src/util.cpp
+++ b/modules/util/src/util.cpp
@@ -1,11 +1,10 @@
 #include "util/include/util.hpp"
 
-#include <mpi.h>
-
 #include <algorithm>
 #include <array>
 #include <filesystem>
 #include <libenvpp/detail/get.hpp>
+#include <mpi.h>
 #include <string>
 
 namespace {
@@ -66,6 +65,15 @@ bool ppc::util::IsUnderMpirun() {
     const auto mpi_env = env::get<int>(env_var);
     return static_cast<bool>(mpi_env.has_value());
   });
+}
+
+void ppc::util::ConfigureMpiEnvironment() {
+#ifdef __APPLE__
+  // Open MPI 5 can emit mmap backing-file probe warnings for macOS TMPDIR paths.
+  if (!env::get<std::string>("OMPI_MCA_shmem").has_value()) {
+    env::detail::set_environment_variable("OMPI_MCA_shmem", "posix");
+  }
+#endif
 }
 
 void ppc::util::SynchronizeMpiRanks() {

--- a/modules/util/src/util.cpp
+++ b/modules/util/src/util.cpp
@@ -1,10 +1,11 @@
 #include "util/include/util.hpp"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <array>
 #include <filesystem>
 #include <libenvpp/detail/get.hpp>
-#include <mpi.h>
 #include <string>
 
 namespace {

--- a/tasks/common/runners/performance.cpp
+++ b/tasks/common/runners/performance.cpp
@@ -177,6 +177,7 @@ int SynchronizeStatus(int local_status, std::string_view stage) {
 }
 
 int RunPerformanceMain(int argc, char **argv) {
+  ppc::util::ConfigureMpiEnvironment();
   const int init_res = MPI_Init(&argc, &argv);
   if (init_res != MPI_SUCCESS) {
     std::cerr << "[  ERROR  ] MPI_Init failed with code " << init_res << '\n';

--- a/tasks/common/runners/performance.cpp
+++ b/tasks/common/runners/performance.cpp
@@ -1,6 +1,7 @@
+#include <gtest/gtest.h>
+
 #include <benchmark/benchmark.h>
 #include <benchmark/reporter.h>
-#include <gtest/gtest.h>
 #include <mpi.h>
 
 #include <chrono>

--- a/tasks/example/processes/t1/tests/functional/main.cpp
+++ b/tasks/example/processes/t1/tests/functional/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <stb/stb_image.h>
 
 #include <algorithm>

--- a/tasks/example/processes/t2/tests/functional/main.cpp
+++ b/tasks/example/processes/t2/tests/functional/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <stb/stb_image.h>
 
 #include <algorithm>

--- a/tasks/example/processes/t3/tests/functional/main.cpp
+++ b/tasks/example/processes/t3/tests/functional/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <stb/stb_image.h>
 
 #include <algorithm>

--- a/tasks/example/threads/tests/functional/main.cpp
+++ b/tasks/example/threads/tests/functional/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <stb/stb_image.h>
 
 #include <algorithm>


### PR DESCRIPTION
Open MPI 5 can warn while probing mmap backing files under macOS TMPDIR paths, so default to the POSIX shmem component before MPI_Init unless the user already configured it
