### PR TITLE
Decouple docs and scoreboard builds from C++ components

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,7 +55,7 @@ jobs:
           python3 scripts/jobs_graph.py --out docs/_static/ci_graph --format svg
       - name: Configure project
         run: >
-          cmake -S . -B build -D USE_DOCS=ON
+          cmake -S . -B build -D USE_DOCS=ON -D PPC_BUILD_COMPONENTS=OFF
       - name: Build i18n
         run: |
           cmake --build build -t docs_gettext -- --quiet
@@ -97,10 +97,10 @@ jobs:
           fi
       - name: CMake configure
         run: |
-          cmake -S . -B build -DUSE_SCOREBOARD=ON
+          cmake -S . -B build -DUSE_SCOREBOARD=ON -DPPC_BUILD_COMPONENTS=OFF
       - name: CMake build
         run: |
-          cmake --build build --parallel -- --quiet
+          cmake --build build -t generate_scoreboard -- --quiet
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,53 +1,58 @@
-cmake_minimum_required( VERSION 3.25 )
+cmake_minimum_required(VERSION 3.25)
 
 if(DEFINED CMAKE_OSX_SYSROOT AND NOT EXISTS "${CMAKE_OSX_SYSROOT}")
   unset(CMAKE_OSX_SYSROOT CACHE)
 endif()
 
-message( STATUS "Parallel Programming Course (PPC)" )
-project(parallel_programming_course)
+message(STATUS "Parallel Programming Course (PPC)")
+project(parallel_programming_course LANGUAGES NONE)
 
-############################ Scoreboard #############################
+option(PPC_BUILD_COMPONENTS
+       "Build C++ modules, tasks, tests, and their dependencies" ON)
 
-message( STATUS "PPC step: Setup scoreboard generator" )
+# ########################### Scoreboard #############################
+
+message(STATUS "PPC step: Setup scoreboard generator")
 include(cmake/scoreboard.cmake)
 add_subdirectory(scoreboard)
 
-########################### Documentation ###########################
+# ########################## Documentation ###########################
 
-message( STATUS "PPC step: Setup documentation generation" )
+message(STATUS "PPC step: Setup documentation generation")
 include(cmake/sphinx.cmake)
 add_subdirectory(docs)
 
-if( USE_SCOREBOARD OR USE_DOCS )
-    return()
+if(PPC_BUILD_COMPONENTS)
+  enable_language(C CXX)
+
+  # ########################### Configures #############################
+
+  message(STATUS "PPC step: First configures")
+  include(cmake/configure.cmake)
+  include(cmake/modes.cmake)
+  include(cmake/sanitizers.cmake)
+  foreach(dep json libenvpp stb)
+    include(cmake/${dep}.cmake)
+  endforeach()
+
+  # ################ Parallel programming technologies #################
+
+  message(STATUS "PPC step: Setup parallel programming technologies")
+  foreach(dep mpi openmp onetbb)
+    include(cmake/${dep}.cmake)
+  endforeach()
+
+  # ######################## External projects #########################
+
+  message(STATUS "PPC step: Setup external projects")
+  include(cmake/gtest.cmake)
+  include(cmake/benchmark.cmake)
+
+  # ############################# Modules ##############################
+
+  message(STATUS "PPC step: Setup modules")
+  add_subdirectory(modules)
+  add_subdirectory(tasks)
+else()
+  message(STATUS "PPC step: Skipping C++ components")
 endif()
-
-############################ Configures #############################
-
-message( STATUS "PPC step: First configures" )
-include(cmake/configure.cmake)
-include(cmake/modes.cmake)
-include(cmake/sanitizers.cmake)
-foreach(dep json libenvpp stb)
-    include(cmake/${dep}.cmake)
-endforeach()
-
-################# Parallel programming technologies #################
-
-message( STATUS "PPC step: Setup parallel programming technologies" )
-foreach(dep mpi openmp onetbb)
-    include(cmake/${dep}.cmake)
-endforeach()
-
-######################### External projects #########################
-
-message( STATUS "PPC step: Setup external projects" )
-include(cmake/gtest.cmake)
-include(cmake/benchmark.cmake)
-
-############################## Modules ##############################
-
-message( STATUS "PPC step: Setup modules" )
-add_subdirectory(modules)
-add_subdirectory(tasks)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,10 @@ pip install -r docs/requirements.txt
 4. Configure the documentation build:
 
 ```bash
-cmake -S . -B build -DUSE_DOCS=ON
+cmake -S . -B build -DUSE_DOCS=ON -DPPC_BUILD_COMPONENTS=OFF
 ```
+
+Note: `-DPPC_BUILD_COMPONENTS=OFF` could be used to configure documentation without C++ project dependencies
 
 5. Generate API documentation with Doxygen:
 

--- a/docs/user_guide/build.rst
+++ b/docs/user_guide/build.rst
@@ -26,6 +26,8 @@ Navigate to the project root.
 
    - ``-D USE_FUNC_TESTS=ON`` enable functional tests.
    - ``-D USE_PERF_TESTS=ON`` enable performance tests.
+   - ``-D PPC_BUILD_COMPONENTS=OFF`` skip C++ modules, tasks, tests, and
+     their dependencies, useful for docs-only or scoreboard-only configurations.
    - ``-D PPC_TASKS=all`` builds every task (default). Pass one task or a semicolon list,
      for example ``-D PPC_TASKS="example"``, to limit the build.
    - ``-D PPC_IMPLEMENTATIONS="seq;omp"`` select implementation folders to

--- a/scoreboard/README.md
+++ b/scoreboard/README.md
@@ -14,6 +14,15 @@ python main.py -o output_directory
 
 Generates `output_directory/index.html` with the scoreboard.
 
+To generate it through CMake without C++ project dependencies:
+
+```bash
+cmake -S . -B build -DUSE_SCOREBOARD=ON -DPPC_BUILD_COMPONENTS=OFF
+cmake --build build -t generate_scoreboard
+```
+
+Note: `-DPPC_BUILD_COMPONENTS=OFF` could be used to configure documentation without C++ project dependencies
+
 ## Configuration
 
 - `data/points-info.yml` - Task points, deadlines, penalties


### PR DESCRIPTION
Make `-DUSE_DOCS` and `-DUSE_SCOREBOARD` flags non-blocking for the project build
