### PR TITLE
[CI] Switch from macOS-latest to macOS-26 (ARM)

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   clang-build:
-    runs-on: macOS-latest
+    runs-on: macOS-26
     strategy:
       matrix:
         build_type: [Release, Debug]
@@ -60,7 +60,7 @@ jobs:
   clang-test:
     needs:
       - clang-build
-    runs-on: macOS-latest
+    runs-on: macOS-26
     steps:
       - uses: actions/checkout@v6
       - name: Install Xcode
@@ -92,7 +92,7 @@ jobs:
   clang-test-extended:
     needs:
       - clang-test
-    runs-on: macOS-latest
+    runs-on: macOS-26
     steps:
       - uses: actions/checkout@v6
       - name: Install Xcode

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -45,7 +45,7 @@ jobs:
           name: perf-stat
           path: perf-stat.zip
   macos-clang-build-perf-stats:
-    runs-on: macOS-latest
+    runs-on: macOS-26
     steps:
       - uses: actions/checkout@v6
       - name: Install Xcode


### PR DESCRIPTION
- do not use rolling version
- macOS-latest is still pointing to macOS-15 as of today: https://github.com/actions/runner-images/blob/73c7fc8ee8b342f20c87fcd2e2179cd9286caeb9/README.md#available-images
