### PR TITLE
Stengthen clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,6 @@ Checks: >
   -cppcoreguidelines-special-member-functions,
   -misc-const-correctness,
   -misc-non-private-member-variables-in-classes,
-  -modernize-avoid-c-arrays,
   -misc-use-internal-linkage,
   -modernize-use-trailing-return-type,
   -portability-avoid-pragma-once,
@@ -103,3 +102,11 @@ CheckOptions:
     value: 1
   - key: cppcoreguidelines-avoid-goto.IgnoreMacros
     value: 1
+  - key: readability-simplify-boolean-expr.ChainedConditionalReturn
+    value: true
+  - key: readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value: true
+  - key: readability-simplify-boolean-expr.SimplifyDeMorgan
+    value: true
+  - key: readability-simplify-boolean-expr.SimplifyDeMorganRelaxed
+    value: true


### PR DESCRIPTION
- Enable modernize-avoid-c-arrays
- Enable more strict options in readability-simplify-boolean-expr